### PR TITLE
Fixing resource references

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -143,8 +143,8 @@ var PptxGenJS = function(){
 		// Add all images
 		for ( var idx=0; idx<gObjPptx.slides.length; idx++ ) {
 			for ( var idy=0; idy<gObjPptx.slides[idx].rels.length; idy++ ) {
-				intRels++;
-				zip.file("ppt/media/image"+intRels+"."+gObjPptx.slides[idx].rels[idy].extn, gObjPptx.slides[idx].rels[idy].data, {base64:true});
+				var id = gObjPptx.slides[idx].rels[idy].rId - 1;
+				zip.file("ppt/media/image"+id+"."+gObjPptx.slides[idx].rels[idy].extn, gObjPptx.slides[idx].rels[idy].data, {base64:true});
 			}
 		}
 


### PR DESCRIPTION
Images are getting displayed on wrong slides because references are getting assigned incorrectly if adding images not sequentially to slides: for example if add image1 to slide2 and then image2 to slide1, they'll be displayed in wrong order.