### PR TITLE
Optional output type

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Quickly and easily create PowerPoint presentations with a few simple JavaScript 
   - [Saving a Presentation](#saving-a-presentation)
     - [Client Browser](#client-browser)
     - [Node.js](#nodejs-1)
+    - [Specific output type](#specific-output-type)
 - [Presentations: Adding Objects](#presentations-adding-objects)
   - [Adding Charts](#adding-charts)
     - [Chart Types](#chart-types)
@@ -287,7 +288,17 @@ pptx.save( 'Node_Demo', saveCallback );
 pptx.save( 'http', streamCallback );
 ```
 
-Saving multiple Presentations:  
+### Specific output type
+When a save callback function is specified (no matter whether on a client or in Node), an extra parametr can be passed – `outputType`.
+This parameter accepts any value of [the JSzip supported formats](https://stuk.github.io/jszip/documentation/api_jszip/generate_async.html). For example:
+
+```javascript
+pptx.save( 'whatever', function(content) {
+  console.log(content);
+}, 'base64');
+```
+
+Saving multiple Presentations:
 * In order to generate a new, unique Presentation just create a new instance of the library then add objects and save as normal.
 
 ```javascript


### PR DESCRIPTION
Sometimes, you don't necessarily need to get a file directly on save. Instead, it can be useful to have an opportunity to adjust the result generated by the library (to post-process it, add extra files or put the file into an archive). 
As the JSZip library provides an option to specify output type, I've added this option to the `save` method as well.