### PR TITLE
Image sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Quickly and easily create PowerPoint presentations with a few simple JavaScript 
   - [Adding Images](#adding-images)
     - [Image Options](#image-options)
     - [Image Examples](#image-examples)
+    - [Image Sizing](#image-sizing)
   - [Adding Media (Audio/Video/YouTube)](#adding-media-audiovideoyoutube)
     - [Media Options](#media-options)
     - [Media Examples](#media-examples)
@@ -909,6 +910,7 @@ Animated GIFs can be included in Presentations in one of two ways:
 | `data`       | string  |        |           | image data (base64) | base64-encoded image string. (either `data` or `path` is required) |
 | `hyperlink`  | string  |        |           | add hyperlink | object with `url` and optionally `tooltip`. Ex: `{ hyperlink:{url:'https://github.com'} }` |
 | `path`       | string  |        |           | image path          | Same as used in an (img src="") tag. (either `data` or `path` is required) |
+| `sizing`     | object  |        |           | transforms image    | See [Image Sizing](#image-sizing) |
 
 **NOTES**
 * SVG images are not currently supported in PowerPoint or PowerPoint Online (even when encoded into base64). PptxGenJS does
@@ -943,7 +945,39 @@ slide.addImage({
 pptx.save('Demo-Images');
 ```
 
+### Image Sizing
+The `sizing` option provides cropping and scaling an image to a specified area. The property expects an object with the following structure:
+| Property     | Type    | Unit   | Default           | Description                                   | Possible Values  |
+| :----------- | :------ | :----- | :---------------- | :-------------------------------------------- | :--------------- |
+| `type`       | string  |        |                   | sizing algorithm                              | `'crop'`, `'contain'` or `'cover'` |
+| `w`          | number  | inches | `w` of the image  | area width                                    | 0-n |
+| `h`          | number  | inches | `h` of the image  | area height                                   | 0-n |
+| `x`          | number  | inches | `0`               | area horizontal position related to the image | 0-n (effective for `crop` only) |
+| `y`          | number  | inches | `0`               | area vertical position related to the image   | 0-n (effective for `crop` only)|
 
+Particular `type` values behave as follows:
+* `contain` works as CSS property `background-size` — shrinks the image (ratio preserved) to the area given by `w` and `h` so that the image is completely visible. If the area's ratio differs from the image ratio, an empty space will surround the image.
+* `cover` works as CSS property `background-size` — shrinks the image (ratio preserved) to the area given by `w` and `h` so that the area is completely filled. If the area's ratio differs from the image ratio, the image is centered to the area and cropped.
+* `crop` cuts off a part specified by image-related coordinates `x`, `y` and size `w`, `h`.
+
+NOTES:
+* If you specify an area size larger than the image for the `contain` and `cover` type, then the image will be stretched, not shrunken.
+* In case of the `crop` option, if the specified area reaches out of the image, then the covered empty space will be a part of the image.
+* When the `sizing` property is used, its `w` and `h` values represent the effective image size. For example, in the following snippet, width and height of the image will both equal to 2 inches and its top-left corner will be located at [1 inch, 1 inch]:
+```javascript
+slide.addImage({
+  path: '...',
+  w: 4,
+  h: 3,
+  x: 1,
+  y: 1,
+  sizing: {
+    type: 'contain',
+    w: 2,
+    h: 2
+  }
+});
+```
 **************************************************************************************************
 ## Adding Media (Audio/Video/YouTube)
 Syntax:

--- a/README.md
+++ b/README.md
@@ -947,6 +947,7 @@ pptx.save('Demo-Images');
 
 ### Image Sizing
 The `sizing` option provides cropping and scaling an image to a specified area. The property expects an object with the following structure:
+
 | Property     | Type    | Unit   | Default           | Description                                   | Possible Values  |
 | :----------- | :------ | :----- | :---------------- | :-------------------------------------------- | :--------------- |
 | `type`       | string  |        |                   | sizing algorithm                              | `'crop'`, `'contain'` or `'cover'` |

--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -997,7 +997,7 @@ var PptxGenJS = function(){
 						strSlideXml += '  </p:nvPicPr>';
 						strSlideXml += '<p:blipFill>';
 						strSlideXml += '  <a:blip r:embed="rId' + slideItemObj.imageRid + '" cstate="print"/>';
-						if (sizing) {
+						if (sizing && sizing.type) {
 							var boxW = sizing.w ? getSmartParseNumber(sizing.w, 'X') : cx,
 								boxH = sizing.h ? getSmartParseNumber(sizing.h, 'Y') : cy,
 								boxX = getSmartParseNumber(sizing.x || 0, 'X'),

--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -319,7 +319,7 @@ var PptxGenJS = function(){
 		 */
 		addImageDefinition: function addImageDefinition(strImagePath, intPosX, intPosY, intWidth, intHeight, strImageData, target) {
 			var resultObject = {};
-
+			var sizing = null;
 			// FIRST: Set vars for this image (object param replaces positional args in 1.1.0)
 			// FIXME: FUTURE: DEPRECATED: Only allow object param in 1.5 or 2.0
 			if ( typeof strImagePath === 'object' ) {
@@ -328,6 +328,7 @@ var PptxGenJS = function(){
 				intPosY = (strImagePath.y || 0);
 				intWidth = (strImagePath.cx || strImagePath.w || 0);
 				intHeight = (strImagePath.cy || strImagePath.h || 0);
+				sizing = strImagePath.sizing || null;
 				objHyperlink = (strImagePath.hyperlink || '');
 				strImageData = (strImagePath.data || '');
 				strImagePath = (strImagePath.path || ''); // IMPORTANT: This line must be last as were about to ovewrite ourself!
@@ -366,7 +367,8 @@ var PptxGenJS = function(){
 				x: (intPosX  || 0),
 				y: (intPosY  || 0),
 				cx: (intWidth || imgObj.width),
-				cy: (intHeight || imgObj.height)
+				cy: (intHeight || imgObj.height),
+				sizing: sizing
 			};
 
 			// STEP 4: Add this image to this Slide Rels (rId/rels count spans all slides! Count all images to get next rId)
@@ -982,6 +984,10 @@ var PptxGenJS = function(){
 						break;
 
 					case 'image':
+						var sizing = slideItemObj.options.sizing,
+							width = cx,
+							height = cy;
+
 						strSlideXml += '<p:pic>';
 						strSlideXml += '  <p:nvPicPr>'
 						strSlideXml += '    <p:cNvPr id="'+ (idx + 2) +'" name="Object '+ (idx + 1) +'" descr="'+ slideItemObj.image +'">';
@@ -989,11 +995,26 @@ var PptxGenJS = function(){
 						strSlideXml += '    </p:cNvPr>';
 						strSlideXml += '    <p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/>';
 						strSlideXml += '  </p:nvPicPr>';
-						strSlideXml += '<p:blipFill><a:blip r:embed="rId' + slideItemObj.imageRid + '" cstate="print"/><a:stretch><a:fillRect/></a:stretch></p:blipFill>';
+						strSlideXml += '<p:blipFill>';
+						strSlideXml += '  <a:blip r:embed="rId' + slideItemObj.imageRid + '" cstate="print"/>';
+						if (sizing) {
+							var boxW = sizing.w ? getSmartParseNumber(sizing.w, 'X') : cx,
+								boxH = sizing.h ? getSmartParseNumber(sizing.h, 'Y') : cy,
+								boxX = getSmartParseNumber(sizing.x || 0, 'X'),
+								boxY = getSmartParseNumber(sizing.y || 0, 'Y');
+
+								strSlideXml += gObjPptxGenerators.imageSizingXml[sizing.type]({w: width, h: height}, {w: boxW, h: boxH, x: boxX, y: boxY});
+							width = boxW;
+							height = boxH;
+						}
+						else {
+							strSlideXml += '  <a:stretch><a:fillRect/></a:stretch>';
+						}
+						strSlideXml += '</p:blipFill>';
 						strSlideXml += '<p:spPr>'
 						strSlideXml += ' <a:xfrm' + locationAttr + '>'
 						strSlideXml += '  <a:off  x="' + x  + '"  y="' + y  + '"/>'
-						strSlideXml += '  <a:ext cx="' + cx + '" cy="' + cy + '"/>'
+						strSlideXml += '  <a:ext cx="' + width + '" cy="' + height + '"/>'
 						strSlideXml += ' </a:xfrm>'
 						strSlideXml += ' <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>'
 						strSlideXml += '</p:spPr>';
@@ -1174,6 +1195,41 @@ var PptxGenJS = function(){
 
 			strXml += '</Relationships>';
 			return strXml;
+		},
+
+		imageSizingXml: {
+			cover: function(imgSize, boxDim) {
+				var imgRatio = imgSize.h / imgSize.w,
+					boxRatio = boxDim.h / boxDim.w,
+					isBoxBased = boxRatio > imgRatio,
+					width = isBoxBased ? (boxDim.h / imgRatio) : boxDim.w,
+					height = isBoxBased ? boxDim.h : (boxDim.w * imgRatio),
+					hzPerc = Math.round(1e5 * 0.5 * (1 - boxDim.w / width)),
+					vzPerc = Math.round(1e5 * 0.5 * (1 - boxDim.h / height));
+				return '<a:srcRect l="' + hzPerc + '" r="' + hzPerc + '" t="' + vzPerc + '" b="' + vzPerc + '" /><a:stretch/>';
+			},
+			contain: function(imgSize, boxDim) {
+				var imgRatio = imgSize.h / imgSize.w,
+					boxRatio = boxDim.h / boxDim.w,
+					widthBased = boxRatio > imgRatio;
+					width =  widthBased ? boxDim.w : (boxDim.h / imgRatio),
+					height = widthBased ? (boxDim.w * imgRatio) : boxDim.h,
+					hzPerc = Math.round(1e5 * 0.5 * (1 - boxDim.w / width)),
+					vzPerc = Math.round(1e5 * 0.5 * (1 - boxDim.h / height));
+				return '<a:srcRect l="' + hzPerc + '" r="' + hzPerc + '" t="' + vzPerc + '" b="' + vzPerc + '" /><a:stretch/>';
+
+			},
+			crop: function(imageSize, boxDim) {
+				var l = boxDim.x,
+					r = imageSize.w - (boxDim.x + boxDim.w),
+					t = boxDim.y,
+					b = imageSize.h - (boxDim.y + boxDim.h),
+					lPerc = Math.round(1e5 * (l / imageSize.w)),
+					rPerc = Math.round(1e5 * (r / imageSize.w)),
+					tPerc = Math.round(1e5 * (t / imageSize.h)),
+					bPerc = Math.round(1e5 * (b / imageSize.h));
+				return '<a:srcRect l="' + lPerc + '" r="' + rPerc + '" t="' + tPerc + '" b="' + bPerc + '" /><a:stretch/>';
+			}
 		},
 
 		/**


### PR DESCRIPTION
This feature enables resizing and cropping images. There are three options available – `cover` and `contain` that work the same as CSS property `background-size` and `crop` option that simply cuts off a part of an image (details in readme section _Image Sizing_). 
When this transformation option is used, the original image size (specified by `w` and `h` image properties) still stays unchanged, only image viewport changes. Thus, user can discard or adjust the transformation in PowerPoint.

Note: This PR **does not** solve issue #87.