### PR TITLE
Color validation

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -173,6 +173,8 @@ var PptxGenJS = function(){
 	this.masters = ( typeof gObjPptxMasters !== 'undefined' ? gObjPptxMasters : {} );
 	/* LEGACY/DEPRECATED ^^^ - WILL BE REMOVED in 2.0 */
 
+	var SCHEME_COLOR_NAMES = Object.keys(this.colors).map(function(clrKey) {return this.colors[clrKey]}.bind(this));
+
 	// D: Fall back to base shapes if shapes file was not linked
 	gObjPptxShapes = ( gObjPptxShapes || this.shapes );
 
@@ -1555,7 +1557,12 @@ var PptxGenJS = function(){
 	 * innerElements (optional string): Additional elements that adjust the color and are enclosed by the color element.
 	 */
 	function createColorElement(colorStr, innerElements) {
-		var tagName = REGEX_HEX_COLOR.test(colorStr) ? 'srgbClr' : 'schemeClr';
+		var isHexaRgb = REGEX_HEX_COLOR.test(colorStr);
+		if (!isHexaRgb && SCHEME_COLOR_NAMES.indexOf(colorStr) === -1) {
+			console.warn('"' + colorStr + '" is not a valid scheme color or hexa RGB, black is used as a fallback. 6-digit RGB or these values are accepted: ' + SCHEME_COLOR_NAMES.join(', '));
+			colorStr = '000000';
+		}
+		var tagName = isHexaRgb ? 'srgbClr' : 'schemeClr';
 		var colorAttr = ' val="'+ colorStr +'"';
 		return innerElements ? '<a:'+ tagName + colorAttr +'>'+ innerElements +'</a:'+ tagName +'>' : '<a:'+ tagName + colorAttr +' />';
 	}


### PR DESCRIPTION
This enhancement prevents silent fallbacking invalid color values to black. Now, if the passed color value does not match hexa RGB format or is not one of the listed scheme colors, a warning appears in console.
The fallback stays the same (black color), however developer is notified of passing invalid value.