### PR TITLE
Line chart series colors were not being respected

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -2646,9 +2646,9 @@ var PptxGenJS = function(){
 								strXml += '<a:ln><a:noFill/></a:ln>';
 							}
 							else {
-								strXml += '<a:solidFill>';
+								strXml += '<a:ln><a:solidFill>';
 								strXml += ' <a:srgbClr val="'+ arrColors[index % arrColors.length] +'"/>';
-								strXml += '</a:solidFill>';
+								strXml += '</a:solidFill></a:ln>';
 							}
 							strXml += createShadowElement(opts.shadow, DEF_SHAPE_SHADOW);
 							strXml += '    </c:spPr>';


### PR DESCRIPTION
Hi Brent,

Ran into a problem trying to get multi line charts to work.  The attached example ([multi.zip](https://github.com/gitbrent/PptxGenJS/files/1341981/multi.zip)) starts with the docs example but I noticed that I kept getting a purple line for my secondary axis:

![image](https://user-images.githubusercontent.com/24831813/30985179-87205400-a45d-11e7-9ff6-99d310b2d5a7.png)

with this change I can get the black line that I was looking for:

![image](https://user-images.githubusercontent.com/24831813/30985090-397d17ba-a45d-11e7-8ece-190bd536bee6.png)



