### PR TITLE
Update for Issue #233

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ slide.addChart({MULTI_TYPES_AND_DATA}, {OPTIONS_AND_AXES});
 | `holeSize`      | number  | percent | `50`      | doughnut hole size                 | 1-100. Ex: `{ holeSize:50 }` |
 | `invertedColors`| array   |         |           | data colors for negative numbers   | array of hex color codes. Ex: `['0088CC','FFCC00']` |
 | `legendFontSize`| number  | points  | `10`      | legend font size                   | 1-256. Ex: `{ legendFontSize: 13 }`|
+| `legendColor`   | string  |         | `000000`  | legend text color                  | hex color code. Ex: `{ legendColor: '0088CC' }` |
 | `legendPos`     | string  |         | `r`       | chart legend position              | `b` (bottom), `tr` (top-right), `l` (left), `r` (right), `t` (top) |
 | `layout`        | object  |         |           | positioning plot within chart area | object with `x`, `y`, `w` and `h` props, all in range 0-1 (proportionally related to the chart size). Ex: `{x: 0, y: 0, w: 1, h: 1}` fully expands chart within the plot area |
 | `showDataTable`           | boolean |     | `false`   | show Data Table under the chart     | `true` or `false` (Not available for Pie/Doughnut charts) |

--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -2565,13 +2565,23 @@ var PptxGenJS = function(){
 				strXml += '<c:legendPos val="'+ rel.opts.legendPos +'"/>';
 				strXml += '<c:layout/>';
 				strXml += '<c:overlay val="0"/>';
-				if ( rel.opts.legendFontSize ) {
+				if ( rel.opts.legendFontSize || rel.opts.legendColor ) {
 					strXml += '<c:txPr>';
 					strXml += '  <a:bodyPr/>';
 					strXml += '  <a:lstStyle/>';
 					strXml += '  <a:p>';
-					strXml += '  <a:pPr>';
-					strXml += '    <a:defRPr sz="'+ (Number(rel.opts.legendFontSize) * 100) +'"/>';
+					strXml += '    <a:pPr>';
+					if ( rel.opts.legendFontSize ) {
+						strXml += '      <a:defRPr sz="'+ (Number(rel.opts.legendFontSize) * 100) +'">';
+					} else {
+						strXml += '      <a:defRPr>';
+					}
+					if ( rel.opts.legendColor ) {
+						strXml += '        <a:solidFill>';
+						strXml += '          <a:srgbClr val="'+ ( rel.opts.legendColor ) +'"/>';
+						strXml += '        </a:solidFill>';
+					}
+					strXml += '      </a:defRPr>';
 					strXml += '    </a:pPr>';
 					strXml += '    <a:endParaRPr lang="en-US"/>';
 					strXml += '  </a:p>';


### PR DESCRIPTION
I added in a new option, `legendColor`.  It behaves similarly to other color options in that it takes a hex color value.  If nothing is specified, PowerPoint seems to always default the color to black.