### PR TITLE
Fixed Error thrown while rendering Area Chart

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -2765,7 +2765,8 @@ var PptxGenJS = function(){
 					strXml += '        </a:defRPr>';
 					strXml += '      </a:pPr></a:p>';
 					strXml += '    </c:txPr>';
-					if ( opts.type != 'area' ) strXml += '<c:dLblPos val="'+ (opts.dataLabelPosition || 'outEnd') +'"/>';
+					// NOTE: opts.type != 'area' has been changed to opts.type.name != 'area'
+					if ( opts.type.name != 'area' ) strXml += '<c:dLblPos val="'+ (opts.dataLabelPosition || 'outEnd') +'"/>';
 					strXml += '    <c:showLegendKey val="0"/>';
 					strXml += '    <c:showVal val="'+ (opts.showValue ? '1' : '0') +'"/>';
 					strXml += '    <c:showCatName val="0"/>';


### PR DESCRIPTION
The edited line in makeChartType() function initially compared opts.type to a string while it is an object containing a property name. Hence it must be changed to :

opts.type.name != 'area'