### PR TITLE
Add radar chart implementation

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -111,7 +111,8 @@ var PptxGenJS = function(){
 		'DOUGHNUT': { 'displayName':'Doughnut Chart', 'name':'doughnut' },
 		'LINE'    : { 'displayName':'Line Chart',     'name':'line'     },
 		'PIE'     : { 'displayName':'Pie Chart' ,     'name':'pie'      },
-		'SCATTER' : { 'displayName':'Scatter Chart',  'name':'scatter'  }
+		'SCATTER' : { 'displayName':'Scatter Chart',  'name':'scatter'  },
+        'RADAR'   : { 'displayName':'Radar Chart',    'name':'radar'    }
 	};
 	var PIECHART_COLORS = ['5DA5DA','FAA43A','60BD68','F17CB0','B2912F','B276B2','DECF3F','F15854','A7A7A7', '5DA5DA','FAA43A','60BD68','F17CB0','B2912F','B276B2','DECF3F','F15854','A7A7A7'];
 	var BARCHART_COLORS = ['C0504D','4F81BD','9BBB59','8064A2','4BACC6','F79646','628FC6','C86360', 'C0504D','4F81BD','9BBB59','8064A2','4BACC6','F79646','628FC6','C86360'];
@@ -521,6 +522,8 @@ var PptxGenJS = function(){
 					}
 				});
 			}
+            if ( ['standard','marker','filled'].indexOf(options.radarStyle || '') < 0 ) options.radarStyle = 'standard';
+
 
 			// Set gridline defaults
 			options.catGridLine = options.catGridLine || (type.name == 'scatter' ? { color:'D9D9D9', pt:1 } : 'none');
@@ -2589,12 +2592,18 @@ var PptxGenJS = function(){
 			case 'area':
 			case 'bar':
 			case 'line':
+            case 'radar':
 				// 1: Start Chart
 				strXml += '<c:'+ chartType +'Chart>';
 				if ( chartType == 'bar' ) {
 					strXml += '<c:barDir val="'+ opts.barDir +'"/>';
 					strXml += '<c:grouping val="'+ opts.barGrouping + '"/>';
 				}
+
+				if ( chartType == 'radar' ) {
+                    strXml += '<c:radarStyle val="'+ opts.radarStyle +'"/>';
+				}
+
 				strXml += '<c:varyColors val="0"/>';
 
 				// 2: "Series" block for every data row
@@ -2658,7 +2667,7 @@ var PptxGenJS = function(){
 					strXml += '  </c:spPr>';
 
 					// 'c:marker' tag: `lineDataSymbol`
-					if ( chartType == 'line' ) {
+					if ( chartType == 'line' || chartType == 'radar') {
 						strXml += '<c:marker>';
 						strXml += '  <c:symbol val="'+ opts.lineDataSymbol +'"/>';
 						if ( opts.lineDataSymbolSize ) {
@@ -2769,7 +2778,7 @@ var PptxGenJS = function(){
 					strXml += '        </a:defRPr>';
 					strXml += '      </a:pPr></a:p>';
 					strXml += '    </c:txPr>';
-					if ( opts.type.name != 'area' ) strXml += '<c:dLblPos val="'+ (opts.dataLabelPosition || 'outEnd') +'"/>';
+					if ( opts.type.name != 'area' && opts.type.name != 'radar') strXml += '<c:dLblPos val="'+ (opts.dataLabelPosition || 'outEnd') +'"/>';
 					strXml += '    <c:showLegendKey val="0"/>';
 					strXml += '    <c:showVal val="'+ (opts.showValue ? '1' : '0') +'"/>';
 					strXml += '    <c:showCatName val="0"/>';
@@ -3255,6 +3264,7 @@ var PptxGenJS = function(){
 
 				// Done with Doughnut/Pie
 				break;
+
 		}
 
 		return strXml;

--- a/examples/pptxgenjs-demo.html
+++ b/examples/pptxgenjs-demo.html
@@ -888,13 +888,18 @@
 							<div class="chkRow"><div class="iconSvg size16 yes"></div>Various Options</div>
 						</fieldset>
 						<fieldset>
-							<legend>Multi-Type Charts</legend>
+							<legend>Radar Chart</legend>
 							<h3>Slide 15</h3>
+							<div class="chkRow"><div class="iconSvg size16 yes"></div>Various Options</div>
+						</fieldset>
+						<fieldset>
+							<legend>Multi-Type Charts</legend>
+							<h3>Slide 16</h3>
 							<div class="chkRow"><div class="iconSvg size16 yes"></div>Various Mixed Chart Types</div>
 						</fieldset>
 						<fieldset>
 							<legend>Chart Options</legend>
-							<h3>Slide 16</h3>
+							<h3>Slide 17</h3>
 							<div class="chkRow"><div class="iconSvg size16 yes"></div>Shadows and Transparent Color</div>
 						</fieldset>
 					</div>

--- a/examples/pptxgenjs-demo.js
+++ b/examples/pptxgenjs-demo.js
@@ -1490,8 +1490,89 @@ function genSlides_Chart(pptx) {
 		slide.addChart( pptx.charts.BUBBLE, arrDataBubble2, optsChartBubble4 );
 	}
 
-	// SLIDE 15: Multi-Type Charts ---------------------------------------------------------
-	function slide15() {
+    // SLIDE 15: Radar Chart ------------------------------------------------------------------
+    function slide15() {
+        var slide = pptx.addNewSlide();
+        slide.addTable( [ [{ text:'Chart Examples: Radar Chart', options:gOptsTextL },gOptsTextR] ], gOptsTabOpts );
+
+        var arrDataRegions = [
+            {
+                name  : 'Region 1',
+                labels: ['May', 'June', 'July', 'August', 'September'],
+                values: [26, 53, 100, 75, 41]
+            }
+        ];
+        var arrDataHighVals = [
+            {
+                name  : 'California',
+                labels: ['Apartment', 'Townhome', 'Duplex', 'House', 'Big House'],
+                values: [2000, 2800, 3200, 4000, 5000]
+            },
+            {
+                name  : 'Texas',
+                labels: ['Apartment', 'Townhome', 'Duplex', 'House', 'Big House'],
+                values: [1400, 2000, 2500, 3000, 3800]
+            }
+        ];
+
+        // TOP-LEFT: Standard
+        var optsChartRadar1 = { x:0.5, y:0.6, w:6.0, h:3.0,
+			radarStyle: 'standard',
+            lineDataSymbol: 'none',
+            fill: 'F1F1F1'
+        };
+        slide.addChart( pptx.charts.RADAR, arrDataRegions, optsChartRadar1 );
+
+        // TOP-RIGHT: Marker
+        var optsChartRadar2 = { x:7.0, y:0.6, w:6.0, h:3.0,
+            radarStyle: 'marker',
+            catAxisLabelColor   : '0000CC',
+            catAxisLabelFontFace: 'Courier',
+            catAxisLabelFontSize: 12
+        };
+        slide.addChart( pptx.charts.RADAR, arrDataRegions, optsChartRadar2 );
+
+        // BTM-LEFT: Filled - TITLE and LEGEND
+        slide.addText( '.', { x:0.5, y:3.8, w:6.0, h:3.5, fill:'F1F1F1', color:'F1F1F1'} );
+        var optsChartRadar3 = { x:0.5, y:3.8, w:6.0, h:3.5,
+            radarStyle: 'filled',
+            catAxisLabelColor   : 'CC0000',
+            catAxisLabelFontFace: 'Helvetica Neue',
+            catAxisLabelFontSize: 14,
+
+            showTitle : true,
+            titleColor   : '33CF22',
+            titleFontFace: 'Helvetica Neue',
+            titleFontSize: 16,
+            title: 'Sales by Region',
+
+            showLegend : true
+        };
+        slide.addChart( pptx.charts.RADAR, arrDataHighVals, optsChartRadar3 );
+
+        // BTM-RIGHT: TITLE and LEGEND
+        slide.addText( '.', { x:7.0, y:3.8, w:6.0, h:3.5, fill:'F1F1F1', color:'F1F1F1'} );
+        var optsChartRadar4 = { x:7.0, y:3.8, w:6.0, h:3.5,
+            radarStyle: 'filled',
+            chartColors: ['0088CC', '99FFCC'],
+
+            catAxisLabelColor   : '0000CC',
+            catAxisLabelFontFace: 'Times',
+            catAxisLabelFontSize: 11,
+            catAxisLineShow: false,
+
+            showLegend : true,
+            legendPos  :  't',
+            legendColor: 'FF0000',
+            showTitle  : true,
+            titleColor : 'FF0000',
+            title      : 'Red Title and Legend'
+        };
+        slide.addChart( pptx.charts.RADAR, arrDataHighVals, optsChartRadar4 );
+    }
+
+	// SLIDE 16: Multi-Type Charts ---------------------------------------------------------
+	function slide16() {
 		// powerpoint 2016 add secondary category axis labels
 		// https://peltiertech.com/chart-with-a-dual-category-axis/
 
@@ -1861,8 +1942,8 @@ function genSlides_Chart(pptx) {
 		//readmeExample();
 	}
 
-	// SLIDE 16: Charts Options: Shadow, Transparent Colors --------------------------------
-	function slide16() {
+	// SLIDE 17: Charts Options: Shadow, Transparent Colors --------------------------------
+	function slide17() {
 		var slide = pptx.addNewSlide();
 		slide.addTable( [ [{ text:'Chart Options: Shadow, Transparent Colors', options:gOptsTextL },gOptsTextR] ], gOptsTabOpts );
 
@@ -1987,6 +2068,7 @@ function genSlides_Chart(pptx) {
 	slide14();
 	slide15();
 	slide16();
+	slide17();
 }
 
 function genSlides_Image(pptx) {


### PR DESCRIPTION
It adds the Radar chart feature.
Most of the existing chart options should be well rendered.
- The following option is specific:

Name | Description
-- | --
 `radarStyle` | `standard` (default),`marker`, `filled`


An example of Radar charts is added in the HTML demo file. (Slide 15 of charts). 
The generated file is OOXML valid and seems to open well with Microsoft Powerpoint 2010 ;)