### PR TITLE
fix: Also add the left align property when generating xml paragraph p…

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -3889,6 +3889,10 @@ var PptxGenJS = function(){
             // OPTION: align
             if ( textObj.options.align ) {
                 switch ( textObj.options.align ) {
+                    case 'l':
+                    case 'left':
+                        paragraphPropXml += ' algn="l"';
+                        break;
                     case 'r':
                     case 'right':
                         paragraphPropXml += ' algn="r"';


### PR DESCRIPTION
I had a problem when using a title placeholder in a master slide:
```
var pptx = new PptxGenJS();
pptx.defineSlideMaster({
  title: 'MASTER_SLIDE',
  objects: [
    { 'placeholder': {
        options: { name:'title', type:'title', x:0.6, y:1.5, w:12, h:5.25, align: 'left' },
        text: '(custom placeholder text!)'
      }
    }
  ]
});
pptx.addNewSlide('MASTER_SLIDE');
pptx.save();
```

When i open the file, the align property is not precised and the default behavior seems to be centered.
As the left case is ignored, i can't force it :(