### PR TITLE
Fix for issue 343

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -2847,6 +2847,7 @@ var PptxGenJS = function(){
 					strXml += '      <c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>'+ encodeXmlEntities(obj.name) +'</c:v></c:pt></c:strCache>';
 					strXml += '    </c:strRef>';
 					strXml += '  </c:tx>';
+					strXml += '  <c:invertIfNegative val="0"/>';
 
 					// Fill and Border
 					var strSerColor = opts.chartColors[colorIndex % opts.chartColors.length];


### PR DESCRIPTION
Added a change to the makeChartType function so that the PowerPoint doesn't invert negative value colors by default.

Test case prior to change:
```
var pptx = new PptxGenJS();
var slide = pptx.addNewSlide();

// Chart Type: BAR
var dataChartBar = [
	{
		name  : 'Region 1',
		labels: ['May', 'June', 'July', 'August'],
		values: [26, 53, -100, 75]
	},
	{
		name  : 'Region 2',
		labels: ['May', 'June', 'July', 'August'],
		values: [43.5, 70.3, 90.1, 80.05]
	}
	];
slide.addChart( pptx.charts.BAR, dataChartBar, { x: 0.97, y: 1.75, w: 8.51, h: 3.32 } );

pptx.save('Sample Presentation');
```


![image](https://user-images.githubusercontent.com/11152426/46978746-bc284a00-d09d-11e8-9a28-aa24a1c9c394.png)

After change results:
![image](https://user-images.githubusercontent.com/11152426/46978785-d8c48200-d09d-11e8-8b62-5efc73b76c59.png)

