### PR TITLE
New Feature - Add support for Min and Max values on X-Axis for Scatter charts

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -3497,7 +3497,12 @@ var PptxGenJS = function(){
 			strXml += '<c:' + (opts.catLabelFormatCode ? 'dateAx' : 'catAx') + '>';
 		}
 		strXml += '  <c:axId val="'+ axisId +'"/>';
-		strXml += '  <c:scaling><c:orientation val="'+ (opts.catAxisOrientation || (opts.barDir == 'col' ? 'minMax' : 'minMax')) +'"/></c:scaling>';
+		strXml += '  <c:scaling><c:orientation val="'+ (opts.catAxisOrientation || (opts.barDir == 'col' ? 'minMax' : 'minMax')) +'"/>';
+		if ( opts.type.name == 'scatter' || opts.type.name == 'bubble' ) {
+			if (opts.catAxisMaxVal || opts.catAxisMaxVal == 0) strXml += '<c:max val="'+ opts.catAxisMaxVal +'"/>';
+			if (opts.catAxisMinVal || opts.catAxisMinVal == 0) strXml += '<c:min val="'+ opts.catAxisMinVal +'"/>';
+		}
+		strXml +='</c:scaling>';
 		strXml += '  <c:delete val="'+ (opts.catAxisHidden ? 1 : 0) +'"/>';
 		strXml += '  <c:axPos val="'+ (opts.barDir == 'col' ? 'b' : 'l') +'"/>';
 		strXml += ( opts.catGridLine !== 'none' ? createGridLineElement(opts.catGridLine, DEF_CHART_GRIDLINE) : '' );


### PR DESCRIPTION
Builds on PR #372  Resolves outstanding part of issue #355 and allows the user to set a minimum and maximum value for the X axis in a Scatter Chart.

Sample usage of the new options:
```
catAxisMinVal:10,
catAxisMaxVal:200
```

Additional note. Major and Minor units are currently supported, but undocumented that you must specify `catLabelFormatCode:'valAx'` for this to work of it bypasses an IF statement. e.g. 
```
catAxisMinorUnit:10,
catAxisMajorUnit:50,
catLabelFormatCode:'valAx'
```