### PR TITLE
BugFix: figuring all nums<100 are inches breaks inserting of small images

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -2149,11 +2149,11 @@ var PptxGenJS = function(){
 
 		// CASE 1: Number in inches
 		// Figure any number less than 100 is inches
-		if ( typeof inVal == 'number' && inVal < 100 ) return inch2Emu(inVal);
+		if ( typeof inVal == 'number' && inVal < 50 ) return inch2Emu(inVal);
 
 		// CASE 2: Number is already converted to something other than inches
 		// Figure any number greater than 100 is not inches! :)  Just return it (its EMU already i guess??)
-		if ( typeof inVal == 'number' && inVal >= 100 ) return inVal;
+		if ( typeof inVal == 'number' && inVal >= 50 ) return inVal;
 
 		// CASE 3: Percentage (ex: '50%')
 		if ( typeof inVal == 'string' && inVal.indexOf('%') > -1 ) {


### PR DESCRIPTION
Currently all sized less than "100" are considered to be in inches (see getSmartParseNumber function). This cause a presentation corruption when inserting small images because their dimensions are being converted. For example image with height 75 px is converted to be about 600000000 px high. I propose to make the border to be at least "50" (could be lowered imo) which should not affect real "inch" sizes since Slide width is about 13''.   