### PR TITLE
BugFix: missing jpg content type breaks corrupts presentation for Office365

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -4156,6 +4156,7 @@ var PptxGenJS = function(){
 		strXml += ' <Default Extension="xml" ContentType="application/xml"/>';
 		strXml += ' <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>';
 		strXml += ' <Default Extension="jpeg" ContentType="image/jpeg"/>';
+        strXml += ' <Default Extension="jpg" ContentType="image/jpg"/>';
 
 		// STEP 1: Add standard/any media types used in Presenation
 		strXml += ' <Default Extension="png" ContentType="image/png"/>';


### PR DESCRIPTION
By default we add only "jpeg" into presentation's content types (see makeXmlContTypes function) but Office365 definitely expects to see "jpg" also and consider some presentations as corrupted depending on certain pictures inserted.  