### PR TITLE
Remove query and fragment from image's extension (Issue #433)

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -405,7 +405,7 @@ var PptxGenJS = function(){
 			}
 
 			// STEP 1: Set extension
-			var strImgExtn = strImagePath.split('.').pop() || 'png';
+			var strImgExtn = strImagePath.split('.').pop().split("?")[0].split("#")[0] || 'png';
 			// However, pre-encoded images can be whatever mime-type they want (and good for them!)
 			if ( strImageData && /image\/(\w+)\;/.exec(strImageData) && /image\/(\w+)\;/.exec(strImageData).length > 0 ) {
 				strImgExtn = /image\/(\w+)\;/.exec(strImageData)[1];


### PR DESCRIPTION
Not setting extension of image correctly seems to result in data corruption in file.
As far as the issue goes, leaving fragment in URL seems file (at least in LibreOffice), but the change will remove it as well just in case.