### PR TITLE
Escape ampersands in URL parameter (Issue #440)

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -416,7 +416,9 @@ var PptxGenJS = function(){
 			}
 			// STEP 2: Set type/path
 			resultObject.type  = 'image';
-			resultObject.image = (strImagePath || 'preencoded.png');
+			// Escape ampersands in URL parameter (Issue#440)
+			var splitImagePath = strImagePath.split("?");
+			resultObject.image = (splitImagePath.length > 1 ? splitImagePath[0] + "?" + splitImagePath.slice(1, splitImagePath.length).join("").replace(/&(?!amp;)/g, "&amp;") : strImagePath || 'preencoded.png');
 
 			// STEP 3: Set image properties & options
 			// FIXME: Measure actual image when no intWidth/intHeight params passed


### PR DESCRIPTION
This is the fix for issue #440.

Upon the investigation, I found out that escaping ampersands in `resultObject` seems to be enough to solve the issue.
The fix itself looks rather complicated, but I also considered cases with multiple `?` in URL.