### PR TITLE
Add an option to change chart tick mark type

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -3650,8 +3650,8 @@ var PptxGenJS = function(){
 			strXml += '  <c:tickLblPos val="nextTo"/>';
 		}
 		else {
-			strXml += '  <c:majorTickMark val="out"/>';
-			strXml += '  <c:minorTickMark val="none"/>';
+			strXml += '  <c:majorTickMark val="' + (opts.valAxisMajorUnitType ? opts.valAxisMajorUnitType : 'out') + '"/>';
+			strXml += '  <c:minorTickMark val="' + (opts.valAxisMinorUnitType ? opts.valAxisMinorUnitType : 'none') + '"/>';
 			strXml += '  <c:tickLblPos val="'+ (opts.catAxisLabelPos || opts.barDir == 'col' ? 'low' : 'nextTo') +'"/>';
 		}
 		strXml += '  <c:spPr>';
@@ -3743,8 +3743,8 @@ var PptxGenJS = function(){
 			strXml += '  <c:tickLblPos val="nextTo"/>';
 		}
 		else {
-			strXml += ' <c:majorTickMark val="out"/>';
-			strXml += ' <c:minorTickMark val="none"/>';
+			strXml += ' <c:majorTickMark val="' + (opts.valAxisMajorUnitType ? opts.valAxisMajorUnitType : 'out') + '"/>';
+			strXml += ' <c:minorTickMark val="' + (opts.valAxisMinorUnitType ? opts.valAxisMinorUnitType : 'none') + '"/>';
 			strXml += ' <c:tickLblPos val="'+ (opts.catAxisLabelPos || opts.barDir == 'col' ? 'nextTo' : 'low') +'"/>';
 		}
 		strXml += ' <c:spPr>';


### PR DESCRIPTION
Hello,

One of the feature which I saw was missing is to change the minor and major tick mark position for charts. For example: whether the tick marks should be inside, outside or cross axis.

Sadly, I am fairly new to development and Github in general, so I do not know how to update the documentation. Readme.md seemed only to have links to the "Adding Charts" page. So any tips or help on how to do that would be really helpful.

Regards,
Rokas