### PR TITLE
New Chart Option: valAxisCrossesAt

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -3609,6 +3609,7 @@ var PptxGenJS = function(){
 
 	function makeCatAxis(opts, axisId, valAxisId) {
 		var strXml = '';
+		var crosses = opts.valAxisCrossesAt ? opts.valAxisCrossesAt : 'autoZero';
 
 		// Build cat axis tag
 		// NOTE: Scatter and Bubble chart need two Val axises as they display numbers on x axis
@@ -3675,7 +3676,7 @@ var PptxGenJS = function(){
 		strXml += '  </a:p>';
 		strXml += ' </c:txPr>';
 		strXml += ' <c:crossAx val="'+ valAxisId +'"/>';
-		strXml += ' <c:crosses val="autoZero"/>';
+		strXml += ' <c:' + ((typeof crosses == "number") ? 'crossesAt' : 'crosses') + ' val="' + crosses + '"/>';
 		strXml += ' <c:auto val="1"/>';
 		strXml += ' <c:lblAlgn val="ctr"/>';
 		strXml += ' <c:noMultiLvlLbl val="1"/>';


### PR DESCRIPTION
Adds a new chart option: valAxisCrossesAt

This allows you to specify where the Category axis crosses the Value Axis.

Acceptable values are:
1. autoZero - Default if not entered
2. max
3. A number within the range of the Value Axis min and max value