### PR TITLE
Issue 470 - Formatting issues when using percentages

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -2162,10 +2162,10 @@ var PptxGenJS = function(){
 
 		// CASE 3: Percentage (ex: '50%')
 		if ( typeof inVal == 'string' && inVal.indexOf('%') > -1 ) {
-			if ( inDir && inDir == 'X') return Math.round( (parseInt(inVal,10) / 100) * gObjPptx.pptLayout.width  );
-			if ( inDir && inDir == 'Y') return Math.round( (parseInt(inVal,10) / 100) * gObjPptx.pptLayout.height );
+			if ( inDir && inDir == 'X') return Math.round( (parseFloat(inVal,10) / 100) * gObjPptx.pptLayout.width  );
+			if ( inDir && inDir == 'Y') return Math.round( (parseFloat(inVal,10) / 100) * gObjPptx.pptLayout.height );
 			// Default: Assume width (x/cx)
-			return Math.round( (parseInt(inVal,10) / 100) * gObjPptx.pptLayout.width );
+			return Math.round( (parseFloat(inVal,10) / 100) * gObjPptx.pptLayout.width );
 		}
 
 		// LAST: Default value


### PR DESCRIPTION
PR for Issue: #470 

Update the getSmartParseNumber function to use parseFloat instead of parseInt.

When defining heights and widths that use a percentage with a decimal number it use causing minor layout issues due the decimal component being dropped.

Sample code to produce layout issue:
```
var pptx = new PptxGenJS();
var slide = pptx.addNewSlide();

slide.addShape(pptx.shapes.RECTANGLE, { x:0, y:1, w:0.87, h:1, fill:'FF0000' });
slide.addShape(pptx.shapes.RECTANGLE, { x:1, y:1, w:0.87, h:1, fill:'FF0000' });
slide.addShape(pptx.shapes.RECTANGLE, { x:2, y:1, w:0.87, h:1, fill:'FF0000' });
slide.addShape(pptx.shapes.RECTANGLE, { x:3, y:1, w:0.87, h:1, fill:'FF0000' });
slide.addShape(pptx.shapes.RECTANGLE, { x:4, y:1, w:0.87, h:1, fill:'FF0000' });
slide.addShape(pptx.shapes.RECTANGLE, { x:5, y:1, w:0.87, h:1, fill:'FF0000' });
slide.addShape(pptx.shapes.RECTANGLE, { x:6, y:1, w:0.87, h:1, fill:'FF0000' });
slide.addShape(pptx.shapes.RECTANGLE, { x:7, y:1, w:0.87, h:1, fill:'FF0000' });
slide.addShape(pptx.shapes.RECTANGLE, { x:8, y:1, w:0.87, h:1, fill:'FF0000' });
slide.addShape(pptx.shapes.RECTANGLE, { x:9, y:1, w:0.87, h:1, fill:'FF0000' });

slide.addShape(pptx.shapes.RECTANGLE, { x:0, y:2, w:'8.7%', h:1, fill:'0000FF' });
slide.addShape(pptx.shapes.RECTANGLE, { x:1, y:2, w:'8.7%', h:1, fill:'0000FF' });
slide.addShape(pptx.shapes.RECTANGLE, { x:2, y:2, w:'8.7%', h:1, fill:'0000FF' });
slide.addShape(pptx.shapes.RECTANGLE, { x:3, y:2, w:'8.7%', h:1, fill:'0000FF' });
slide.addShape(pptx.shapes.RECTANGLE, { x:4, y:2, w:'8.7%', h:1, fill:'0000FF' });
slide.addShape(pptx.shapes.RECTANGLE, { x:5, y:2, w:'8.7%', h:1, fill:'0000FF' });
slide.addShape(pptx.shapes.RECTANGLE, { x:6, y:2, w:'8.7%', h:1, fill:'0000FF' });
slide.addShape(pptx.shapes.RECTANGLE, { x:7, y:2, w:'8.7%', h:1, fill:'0000FF' });
slide.addShape(pptx.shapes.RECTANGLE, { x:8, y:2, w:'8.7%', h:1, fill:'0000FF' });
slide.addShape(pptx.shapes.RECTANGLE, { x:9, y:2, w:'8.7%', h:1, fill:'0000FF' });

pptx.save('PptxGenJS-Sandbox_'+getTimestamp());
```
Sample decks showing the before and after difference based on the above sample code.
[parseInt Example.pptx](https://github.com/gitbrent/PptxGenJS/files/2755826/parseInt.Example.pptx)
[parseFloat Example.pptx](https://github.com/gitbrent/PptxGenJS/files/2755827/parseFloat.Example.pptx)
