### PR TITLE
BugFix: Hyperlinks causing duplicate relationship ID when other objects on page

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -2197,7 +2197,7 @@ var PptxGenJS = function(){
 				if ( typeof text.options.hyperlink !== 'object' ) console.log("ERROR: text `hyperlink` option should be an object. Ex: `hyperlink: {url:'https://github.com'}` ");
 				else if ( !text.options.hyperlink.url && !text.options.hyperlink.slide ) console.log("ERROR: 'hyperlink requires either: `url` or `slide`'");
 				else {
-					var intRels = 1;
+					var intRels = 0;
 					gObjPptx.slides.forEach(function(slide,idx){ intRels += slide.rels.length; });
 					var intRelId = intRels+1;
 


### PR DESCRIPTION
Bugfix for issue #465
Possible that it also resolves #454 but need more info from OP

When at least 1 hyperlink is included on a slide with another object such as a chart, image, video, audio etc, it creates a duplicate relationship ID as seen in the slide#.xml.rels file which leads to a corruption warning when opening the file.

Fix is to modify the var intRels = 1; to start counting from 0 when creating hyperlink rels.

I've tested with a variety of combinations

Sample Test Code - ( It's not pretty, works as proof of concept )
```
var pptx = new PptxGenJS();
var slide = pptx.addNewSlide();

// EX: Hyperlink: Web
slide.addText(
    [{
        text: 'PptxGenJS Project',
        options: { hyperlink:{ url:'https://github.com/gitbrent/pptxgenjs', tooltip:'Visit Homepage' } }
    }],
    { x:1.0, y:1.0, w:5, h:1 }
);

// EX: Image from remote URL
slide.addImage({ path:'https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg', x:1, y:1, w:6, h:4 })

// Chart Type: RADAR
var dataChartRadar = [
    {
        name  : 'Region 1',
        labels: ['May', 'June', 'July', 'August', 'September'],
        values: [26, 53, 100, 75, 41]
    }
];
slide.addChart( pptx.charts.RADAR, dataChartRadar, { x:0.5, y:0.6, w:6.0, h:4, radarStyle:'standard' } );

// EX: Hyperlink: Slide in Presentation
slide.addText(
    [{
        text: 'Slide #2',
        options: { hyperlink:{ slide:'2', tooltip:'Go to Summary Slide' } }
    }],
    { x:1.0, y:2.5, w:5, h:1 }
);

pptx.save('PptxGenJS-Sandbox_'+getTimestamp());
```

slide1.xml.rels - PRE PATCH
```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
    <Relationship Id="rId2" Target="https://github.com/gitbrent/pptxgenjs" TargetMode="External" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"/>
    <Relationship Id="rId2" Target="../media/image1.jpg" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
    <Relationship Id="rId3" Target="/ppt/charts/chart1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"/>
    <Relationship Id="rId5" Target="slide2.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide"/>
    <Relationship Id="rId6" Target="../slideLayouts/slideLayout1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout"/>
    <Relationship Id="rId7" Target="../notesSlides/notesSlide1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesSlide"/>
</Relationships>
```

slide1.xml.rels - POST PATCH
```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
    <Relationship Id="rId1" Target="https://github.com/gitbrent/pptxgenjs" TargetMode="External" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"/>
    <Relationship Id="rId2" Target="../media/image1.jpg" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
    <Relationship Id="rId3" Target="/ppt/charts/chart1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"/>
    <Relationship Id="rId4" Target="slide2.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide"/>
    <Relationship Id="rId5" Target="../slideLayouts/slideLayout1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout"/>
    <Relationship Id="rId6" Target="../notesSlides/notesSlide1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesSlide"/>
</Relationships>
```