### PR TITLE
fix ordering of paragraph properties

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -4229,8 +4229,9 @@ var PptxGenJS = function(){
 			}
 
 			// Close Paragraph-Properties --------------------
-			// IMPORTANT: strXmlLnSpc must precede strXmlBullet for bullet lineSpacing to work (PPT-Online)
-			paragraphPropXml += '>'+ strXmlParaSpc + strXmlLnSpc + strXmlBullet;
+			// IMPORTANT: strXmlLnSpc, strXmlParaSpc, and strXmlBullet require strict ordering.
+			//            anything out of order is ignored. (PPT-Online, PPT for Mac)
+			paragraphPropXml += '>' + strXmlLnSpc + strXmlParaSpc + strXmlBullet;
 			if (isDefault) {
 				paragraphPropXml += genXmlTextRunProperties(textObj.options, true);
 			}


### PR DESCRIPTION
strXmlParaSpc needs to be after strXmlLnSpc in order for them both to take effect.

Observed bug:
Using linespacing in conjunction with paragraph spacing causes linespacing to be ignored in powerpoint for mac. (I didn't test other versions)

Example code to showcase this bug and the fix:
```
var PptxGenJS = require('./dist/pptxgen');
var pptx = new PptxGenJS();
var slide = pptx.addNewSlide();
slide.addText('Hello World!', { x:1.5, y:1.5, fontSize:18, lineSpacing: 24, paraSpaceBefore: 8 });
pptx.save('Sample Presentation');
```

open "Sample Presentation" with powerpoint,
click inside "Hello World"
choose Paragraph from the format menu

with the fix you should see Spacing Before as 8, and Line Spacing as 24.
without the fix you should see Spacing Before as 8, and Line Spacing as 0


Also I didn't include the minified etc. changes in this patch to keep it simpler. Happy to run a build and include them if that's preferred.