### PR TITLE
Link directly to the StackOverflow PptxGenJS tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ If you are having issues getting a presentation to generate, check out the demos
 are demos for both Nodejs and client-browsers that contain working examples of every available library feature.
 
 * Use a pre-configured jsFiddle to test with: [PptxGenJS Fiddle](https://jsfiddle.net/gitbrent/gx34jy59/)
-* Use Ask Question on [StackOverflow](http://stackoverflow.com/) - be sure to tag it with "PptxGenJS"
+* [View questions tagged `PptxGenJS` on StackOverflow](https://stackoverflow.com/questions/tagged/pptxgenjs?sort=votes&pageSize=50).  If you can't find your question, [ask it yourself](https://stackoverflow.com/questions/ask?tags=PptxGenJS) - be sure to tag it `PptxGenJS`.
 
 
 **************************************************************************************************


### PR DESCRIPTION
This links (1) to prior answers tagged `PptxGenJS` and (2) to a new question template including the `PptxGenJs` tag.