### PR TITLE
Add types key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 	"homepage": "https://gitbrent.github.io/PptxGenJS/",
 	"license": "MIT",
 	"main": "dist/pptxgen.min.js",
+	"types": "dist/pptxgen.d.ts",
 	"dependencies": {
 		"express": "^4.16.4",
 		"https": "^1.0.0",


### PR DESCRIPTION
On the latest Typescript, I couldn't get the Typescript compiler or VS Code to recognize that the `pptxgenjs` library had a typings file. 

Adding this `types` key [seems to be required](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) if the `*.d.ts` file isn't at the root of the project.

Thanks for maintaining this project!