### PR TITLE
Fix Issue 414: outputType being Ignored

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -1761,7 +1761,7 @@ var PptxGenJS = function(){
 	/**
 	 * DESC: Export the .pptx file
 	 */
-	function doExportPresentation(outputType) {
+	function doExportPresentation() {
 		var arrChartPromises = [];
 		var intSlideNum = 0, intRels = 0, intNotesRels = 0;
 
@@ -1825,6 +1825,7 @@ var PptxGenJS = function(){
 		Promise.all( arrChartPromises )
 		.then(function(arrResults){
 			var strExportName = ((gObjPptx.fileName.toLowerCase().indexOf('.ppt') > -1) ? gObjPptx.fileName : gObjPptx.fileName+gObjPptx.fileExtn);
+			var outputType = gObjPptx.outputType;
 			if ( outputType && JSZIP_OUTPUT_TYPES.indexOf(outputType) >= 0 ) {
 				zip.generateAsync({ type:outputType }).then(gObjPptx.saveCallback);
 			}
@@ -5030,6 +5031,7 @@ var PptxGenJS = function(){
 		// STEP 2: Set export properties
 		if ( funcCallback ) gObjPptx.saveCallback = funcCallback;
 		if ( inStrExportName ) gObjPptx.fileName = inStrExportName;
+		if ( outputType ) gObjPptx.outputType = outputType;
 
 		// STEP 3: Read/Encode Images
 		// PERF: Only send unique paths for encoding (encoding func will find and fill *ALL* matching paths across the Presentation)
@@ -5044,7 +5046,7 @@ var PptxGenJS = function(){
 		intRels += encodeSlideMediaRels(gObjPptx.masterSlide, arrRelsDone);
 
 		// STEP 4: Export now if there's no images to encode (otherwise, last async imgConvert call above will call exportFile)
-		if ( intRels == 0 ) doExportPresentation(outputType);
+		if ( intRels == 0 ) doExportPresentation();
 	};
 
 	/**


### PR DESCRIPTION
Bug fix for issue #414 

Previously, `outputType` was not passed to `doExportPresentation()` when the function gets called in `callbackImgToDataURLDone()`. This mean that if the output pptx had any data that required base64 conversion, the output type would be disregarded.

This PR sets `outputType` to be part of `gObjPptx` when the user calls `pptx.save()`. Then when `doExportPresentation()` gets called, `outputType` will be fetched from `gObjPptx`