### PR TITLE
adds ability to specify paragraph indent in text options to adjust gap between bullet and text

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -160,6 +160,7 @@ var PptxGenJS = function(){
 	var AXIS_ID_CATEGORY_PRIMARY = '2094734554';
 	var AXIS_ID_CATEGORY_SECONDARY = '2094734555';
     var AXIS_ID_SERIES_PRIMARY = '2094734556';
+	var DEF_PARA_INDENT = 27; // Default para indent for bullets was defined as 342900 EMU which translates to 27 points with one point being equal to 12700 EMU
 
 	// A: Create internal pptx object
 	var gObjPptx = {};
@@ -4150,7 +4151,7 @@ var PptxGenJS = function(){
 
 	function genXmlParagraphProperties(textObj, isDefault) {
 		var strXmlBullet = '', strXmlLnSpc = '', strXmlParaSpc = '';
-		var bulletLvl0Margin = 342900;
+		var bulletLvl0Margin = DEF_PARA_INDENT * ONEPT;
 		var tag = isDefault ? 'a:lvl1pPr' : 'a:pPr';
 
 		var paragraphPropXml = '<' + tag + (textObj.options.rtlMode ? ' rtl="1" ' : '');
@@ -4178,6 +4179,10 @@ var PptxGenJS = function(){
 						break;
 				}
 			}
+
+      if (textObj.options.paraIndent) {
+        bulletLvl0Margin = textObj.options.paraIndent * ONEPT;
+      }
 
 			if ( textObj.options.lineSpacing ) {
 				strXmlLnSpc = '<a:lnSpc><a:spcPts val="' + textObj.options.lineSpacing + '00"/></a:lnSpc>';


### PR DESCRIPTION
Adds ability to specify paragraph indent for the bulleted text in text options to control the gap between the bullet and the text.

Related issue: https://github.com/gitbrent/PptxGenJS/issues/504