### PR TITLE
Text in slides does not override the bullet master

### DIFF
--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -820,6 +820,11 @@ export function addTextDefinition(target: ISlide, text: string | IText[], opts: 
 			opt.color = opt.color || target.color || DEF_FONT_COLOR // Set color (options > inherit from Slide > default to black)
 		}
 
+		// A.2: Placeholder should inherit their bullets or override them, so don't default them
+		if (!opt.placeholder || isPlaceholder) {
+			opt.bullet = opt.bullet || false
+		}
+
 		// B
 		if (opt.shape && opt.shape.name === 'line') {
 			opt.line = opt.line || '333333'

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -911,8 +911,10 @@ function genXmlParagraphProperties(textObj: ISlideObject | IText, isDefault: boo
 				bulletLvl0Margin +
 				'"'
 			strXmlBullet = '<a:buSzPct val="100000"/><a:buChar char="' + BULLET_TYPES['DEFAULT'] + '"/>'
-		} else {
-			strXmlBullet = '<a:buNone/>'
+		} else if ( textObj.options.bullet === false ){
+        // We only add this when the user explicitely asks for no bullet.
+        // Otherwise it can override the master defaults
+			strXmlBullet = '<a:buNone/>';
 		}
 
 		// B: Close Paragraph-Properties


### PR DESCRIPTION
In the previous version, it overrides it by default