### PR TITLE
The paragraph body of placeholder is formatted

### DIFF
--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -851,6 +851,7 @@ export function addTextDefinition(target: ISlide, text: string | IText[], opts: 
 
 		if ((newObject.options.valign || '').toLowerCase().startsWith('b')) newObject.options.bodyProp.anchor = TEXT_VALIGN.b
 		else if ((newObject.options.valign || '').toLowerCase().startsWith('c')) newObject.options.bodyProp.anchor = TEXT_VALIGN.ctr
+		else if ((newObject.options.valign || '').toLowerCase().startsWith('m')) newObject.options.bodyProp.anchor = TEXT_VALIGN.ctr
 		else if ((newObject.options.valign || '').toLowerCase().startsWith('t')) newObject.options.bodyProp.anchor = TEXT_VALIGN.t
 	}
 
@@ -859,6 +860,7 @@ export function addTextDefinition(target: ISlide, text: string | IText[], opts: 
 
 	// STEP 4: Create hyperlinks
 	createHyperlinkRels(target, newObject.text || '')
+
 
 	// LAST: Add object to Slide
 	target.data.push(newObject)

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -1036,7 +1036,7 @@ function genXmlTextRun(textObj: IText): string {
 function genXmlBodyProperties(slideObject: ISlideObject | ITableCell): string {
 	let bodyProperties = '<a:bodyPr'
 
-	if (slideObject && slideObject.type === SLIDE_OBJECT_TYPES.text && slideObject.options.bodyProp) {
+	if (slideObject && (slideObject.type === SLIDE_OBJECT_TYPES.text || slideObject.type === SLIDE_OBJECT_TYPES.placeholder) && slideObject.options.bodyProp) {
 		// PPT-2019 EX: <a:bodyPr wrap="square" lIns="1270" tIns="1270" rIns="1270" bIns="1270" rtlCol="0" anchor="ctr"/>
 
 		// A: Enable or disable textwrapping none or square


### PR DESCRIPTION
This was breaking anchoring (valign) for placeholder.

While I was there, I also added support for `valign = middle` that was broken (while center worked)