### PR TITLE
Also generate text-related options for placeholders

### DIFF
--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -1036,7 +1036,7 @@ function genXmlTextRun(textObj: IText): string {
 function genXmlBodyProperties(slideObject: ISlideObject | ITableCell): string {
 	let bodyProperties = '<a:bodyPr'
 
-	if (slideObject && slideObject.type === SLIDE_OBJECT_TYPES.text && slideObject.options.bodyProp) {
+	if (slideObject && (slideObject.type === SLIDE_OBJECT_TYPES.text || slideObject.type === SLIDE_OBJECT_TYPES.placeholder) && slideObject.options.bodyProp) {
 		// PPT-2019 EX: <a:bodyPr wrap="square" lIns="1270" tIns="1270" rIns="1270" bIns="1270" rtlCol="0" anchor="ctr"/>
 
 		// A: Enable or disable textwrapping none or square


### PR DESCRIPTION
Otherwise options such as `valign` (aka `bodyProp.anchor`) will not be generated