### PR TITLE
Include types in package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "main": "dist/pptxgen.cjs.js",
   "module": "dist/pptxgen.es.js",
   "files": [
-    "dist"
+    "dist",
+    "types"
   ],
   "types": "types",
   "scripts": {


### PR DESCRIPTION
When I cloned this repo down there were no types included since they are no longer in the `dist` directory. This will include them in the downloaded package files.