### PR TITLE
Add option to Show Leader Lines in charts

### DIFF
--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -165,6 +165,7 @@ export interface IChartOpts extends PositionOptions, OptsChartGridLine {
 	holeSize?: number
 	showTitle?: boolean
 	showValue?: boolean
+	showLeaderLines?: boolean
 	showPercent?: boolean
 	catLabelFormatCode?: string
 	dataBorder?: IBorderOptions

--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -752,7 +752,7 @@ function makeChartType(chartType: CHART_TYPE_NAMES, data: OptsChartData[], opts:
 					strXml += '    <c:showSerName val="0"/>'
 					strXml += '    <c:showPercent val="0"/>'
 					strXml += '    <c:showBubbleSize val="0"/>'
-					strXml += '    <c:showLeaderLines val="0"/>'
+					strXml += '    <c:showLeaderLines val="' + (opts.showLeaderLines ? '1' : '0') + '"/>'
 					strXml += '  </c:dLbls>'
 				}
 
@@ -889,7 +889,7 @@ function makeChartType(chartType: CHART_TYPE_NAMES, data: OptsChartData[], opts:
 				strXml += '    <c:showSerName val="0"/>'
 				strXml += '    <c:showPercent val="0"/>'
 				strXml += '    <c:showBubbleSize val="0"/>'
-				strXml += '    <c:showLeaderLines val="0"/>'
+				strXml += '    <c:showLeaderLines val="' + (opts.showLeaderLines ? '1' : '0') + '"/>'
 				strXml += '  </c:dLbls>'
 			}
 
@@ -1483,7 +1483,7 @@ function makeChartType(chartType: CHART_TYPE_NAMES, data: OptsChartData[], opts:
 			strXml += '	<c:showSerName val="0"/>'
 			strXml += '	<c:showPercent val="1"/>'
 			strXml += '	<c:showBubbleSize val="0"/>'
-			strXml += '	<c:showLeaderLines val="0"/>'
+			strXml += '	<c:showLeaderLines val="' + (opts.showLeaderLines ? '1' : '0') + '"/>'
 			strXml += '</c:dLbls>'
 
 			// 2: "Categories"

--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -231,6 +231,7 @@ export function addChartDefinition(target: ISlide, type: CHART_TYPE_NAMES | ICha
 	options.showPercent = options.showPercent === true || options.showPercent === false ? options.showPercent : true
 	options.showTitle = options.showTitle === true || options.showTitle === false ? options.showTitle : false
 	options.showValue = options.showValue === true || options.showValue === false ? options.showValue : false
+	options.showLeaderLines = options.showLeaderLines === true || options.showLeaderLines === false ? options.showLeaderLines : false
 	options.catAxisLineShow = typeof options.catAxisLineShow !== 'undefined' ? options.catAxisLineShow : true
 	options.valAxisLineShow = typeof options.valAxisLineShow !== 'undefined' ? options.valAxisLineShow : true
 	options.serAxisLineShow = typeof options.serAxisLineShow !== 'undefined' ? options.serAxisLineShow : true

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -301,6 +301,7 @@ declare namespace PptxGenJS {
 		holeSize?: number
 		showTitle?: boolean
 		showValue?: boolean
+		showLeaderLines?: boolean
 		showPercent?: boolean
 		catLabelFormatCode?: string
 		dataBorder?: IBorderOptions


### PR DESCRIPTION
Exposes the Show Leader Lines Format Data Label option.

Panel in PowerPoint:
![image](https://user-images.githubusercontent.com/638332/72086110-64928180-32d4-11ea-80e0-371e644c578e.png)

Without Show Leader Lines:
![image](https://user-images.githubusercontent.com/638332/72086004-4036a500-32d4-11ea-9d99-539bb63ea442.png)

With Show Leader Lines:
![image](https://user-images.githubusercontent.com/638332/72086053-52b0de80-32d4-11ea-974c-ee92ad6b2510.png)

