### PR TITLE
Fix margin type in ITextOpts

### DIFF
--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -355,7 +355,7 @@ export interface ITextOpts extends PositionOptions, OptsDataOrPath {
 	lineIdx?: number
 	lineSize?: number
 	lineSpacing?: number
-	margin?: number
+	margin?: Margin
 	outline?: { color: Color; size: number }
 	paraSpaceAfter?: number
 	paraSpaceBefore?: number

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -491,7 +491,7 @@ declare namespace PptxGenJS {
 		lineIdx?: number
 		lineSize?: number
 		lineSpacing?: number
-		margin?: number
+		margin?: Margin
 		outline?: { color: Color; size: number }
 		paraSpaceAfter?: number
 		paraSpaceBefore?: number


### PR DESCRIPTION
I broke the build when I added the `margin?: number` type. It should be of `Margin` type. My mistake! Build should work now.