### PR TITLE
Add option to set the format code of chart data tables

### DIFF
--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -851,7 +851,7 @@ function makeChartType(chartType: CHART_NAME, data: OptsChartData[], opts: IChar
 					strXml += '    <c:numRef>'
 					strXml += '      <c:f>Sheet1!$' + getExcelColName(idx + 1) + '$2:$' + getExcelColName(idx + 1) + '$' + (obj.labels.length + 1) + '</c:f>'
 					strXml += '      <c:numCache>'
-					strXml += '        <c:formatCode>General</c:formatCode>'
+					strXml += '        <c:formatCode>' + (opts.dataTableFormatCode || 'General') + '</c:formatCode>'
 					strXml += '	       <c:ptCount val="' + obj.labels.length + '"/>'
 					obj.values.forEach((value, idx) => {
 						strXml += '<c:pt idx="' + idx + '"><c:v>' + (value || value === 0 ? value : '') + '</c:v></c:pt>'


### PR DESCRIPTION
Since it's possible and looks nicer to set a number format (in my case: thousands separators) for the value axis labels, it seems prudent to allow setting the same format code for values in the data table as well.

fixes #489