### PR TITLE
Fix bluebird warning when executing pptx.stream()

### DIFF
--- a/src/pptxgen.ts
+++ b/src/pptxgen.ts
@@ -523,7 +523,7 @@ export default class PptxGenJS implements IPresentation {
 						.then(() => {
 							if (outputType === 'STREAM') {
 								// A: stream file
-								zip.generateAsync({ type: 'nodebuffer' }).then(content => {
+								return zip.generateAsync({ type: 'nodebuffer' }).then(content => {
 									resolve(content)
 								})
 							} else if (outputType) {


### PR DESCRIPTION
Hi there, fixing the issue reporting earlier today. Cheers!

Fixes #719 