### PR TITLE
Add the slide layout name to the generated background image name

### DIFF
--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -922,7 +922,7 @@ function addBackgroundDefinition(bkg: string | BkgdOpts, target: ISlideLib | ISl
 			extn: strImgExtn,
 			data: bkg.data || null,
 			rId: intRels,
-			Target: '../media/image' + (target.relsMedia.length + 1) + '.' + strImgExtn,
+			Target: '../media/' + target.name + '-image-' + (target.relsMedia.length + 1) + '.' + strImgExtn,
 		})
 		target.bkgdImgRid = intRels
 	} else if (bkg && typeof bkg === 'string') {


### PR DESCRIPTION
Currently when adding multiple master slides with background images, their background image is being overwritten with the last master slide's background image. Fixes issue #663 