### PR TITLE
Chart Validation

### DIFF
--- a/dist/pptxgen.es.js
+++ b/dist/pptxgen.es.js
@@ -3095,23 +3095,56 @@ function addChartDefinition(target, type, data, opt) {
     // B: Options: misc
     if (['bar', 'col'].indexOf(options.barDir || '') < 0)
         options.barDir = 'col';
-    // IMPORTANT: 'bestFit' will cause issues with PPT-Online in some cases, so defualt to 'ctr'!
-    if (['bestFit', 'b', 'ctr', 'inBase', 'inEnd', 'l', 'outEnd', 'r', 't'].indexOf(options.dataLabelPosition || '') < 0)
-        options.dataLabelPosition = options._type === CHART_TYPE.PIE || options._type === CHART_TYPE.DOUGHNUT ? 'bestFit' : 'ctr';
-    options.dataLabelBkgrdColors = options.dataLabelBkgrdColors === true || options.dataLabelBkgrdColors === false ? options.dataLabelBkgrdColors : false;
-    if (['b', 'l', 'r', 't', 'tr'].indexOf(options.legendPos || '') < 0)
-        options.legendPos = 'r';
+
     // barGrouping: "21.2.3.17 ST_Grouping (Grouping)"
-    if (['clustered', 'standard', 'stacked', 'percentStacked'].indexOf(options.barGrouping || '') < 0)
-        options.barGrouping = 'standard';
-    if (options.barGrouping.indexOf('tacked') > -1) {
-        options.dataLabelPosition = 'ctr'; // IMPORTANT: PPT-Online will not open Presentation when 'outEnd' etc is used on stacked!
+    // Must be done before data label validation
+    if (options._type === CHART_TYPE.AREA) {
+        if (['stacked','standard', 'percentStacked'].indexOf(options.barGrouping || '') < 0)
+            options.barGrouping = 'standard';
+    }
+    if (options._type === CHART_TYPE.BAR) {
+        if (['clustered', 'stacked', 'percentStacked'].indexOf(options.barGrouping || '') < 0)
+            options.barGrouping = 'clustered';
+    }
+    if (options._type === CHART_TYPE.BAR3D) {
+            if (['clustered', 'stacked','standard', 'percentStacked'].indexOf(options.barGrouping || '') < 0)
+                options.barGrouping = 'standard';
+    }
+    if (options.barGrouping && options.barGrouping.indexOf('tacked') > -1) {
         if (!options.barGapWidthPct)
             options.barGapWidthPct = 50;
     }
+    // Clean up and validate data label positions
+    // REFERENCE: https://docs.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/e2b1697c-7adc-463d-9081-3daef72f656f?redirectedfrom=MSDN
+    if (options.dataLabelPosition) {
+        if (options._type === CHART_TYPE.AREA || options._type === CHART_TYPE.BAR3D || options._type === CHART_TYPE.DOUGHNUT || options._type === CHART_TYPE.RADAR)
+            delete options.dataLabelPosition 
+        if (options._type === CHART_TYPE.PIE) {
+            if (['bestFit', 'ctr', 'inEnd', 'outEnd'].indexOf(options.dataLabelPosition) < 0)
+                delete options.dataLabelPosition;
+        }
+        if (options._type === CHART_TYPE.BUBBLE || options._type === CHART_TYPE.LINE || options._type === CHART_TYPE.SCATTER) {
+            if (['b', 'ctr', 'l', 'r', 't'].indexOf(options.dataLabelPosition) < 0)
+                delete options.dataLabelPosition;
+        }
+        if (options._type === CHART_TYPE.BAR) {
+            if (['stacked', 'percentStacked'].indexOf(options.barGrouping || '') < 0) {
+                if (['ctr','inBase', 'inEnd'].indexOf(options.dataLabelPosition) < 0)
+                    delete options.dataLabelPosition;
+            }
+            if (['clustered'].indexOf(options.barGrouping || '') < 0) {
+                if (['ctr','inBase', 'inEnd','outEnd'].indexOf(options.dataLabelPosition) < 0)
+                delete options.dataLabelPosition;
+            }
+        }
+    }
+
+    options.dataLabelBkgrdColors = options.dataLabelBkgrdColors === true || options.dataLabelBkgrdColors === false ? options.dataLabelBkgrdColors : false;
+    if (['b', 'l', 'r', 't', 'tr'].indexOf(options.legendPos || '') < 0)
+        options.legendPos = 'r';
     // 3D bar: ST_Shape
     if (['cone', 'coneToMax', 'box', 'cylinder', 'pyramid', 'pyramidToMax'].indexOf(options.bar3DShape || '') < 0)
-        options.bar3DShape = 'box';
+        options.bar3DShape = 'box';     
     // lineDataSymbol: http://www.datypic.com/sc/ooxml/a-val-32.html
     // Spec has [plus,star,x] however neither PPT2013 nor PPT-Online support them
     if (['circle', 'dash', 'diamond', 'dot', 'none', 'square', 'triangle'].indexOf(options.lineDataSymbol || '') < 0)
@@ -4772,11 +4805,8 @@ function makeChartType(chartType, data, opts, valAxisId, catAxisId, isMultiTypeC
                     strXml += '        </a:defRPr>';
                     strXml += '      </a:pPr></a:p>';
                     strXml += '    </c:txPr>';
-                    // Setting dLblPos tag for bar3D seems to break the generated chart
-                    if (chartType !== CHART_TYPE.AREA && chartType !== CHART_TYPE.BAR3D) {
-                        if (opts.dataLabelPosition)
-                            strXml += ' <c:dLblPos val="' + opts.dataLabelPosition + '"/>';
-                    }
+                    if (opts.dataLabelPosition)
+                        strXml += ' <c:dLblPos val="' + opts.dataLabelPosition + '"/>';
                     strXml += '    <c:showLegendKey val="0"/>';
                     strXml += '    <c:showVal val="' + (opts.showValue ? '1' : '0') + '"/>';
                     strXml += '    <c:showCatName val="0"/>';
@@ -4905,11 +4935,8 @@ function makeChartType(chartType, data, opts, valAxisId, catAxisId, isMultiTypeC
                 strXml += '        </a:defRPr>';
                 strXml += '      </a:pPr></a:p>';
                 strXml += '    </c:txPr>';
-                // NOTE: Throwing an error while creating a multi type chart which contains area chart as the below line appears for the other chart type.
-                // Either the given change can be made or the below line can be removed to stop the slide containing multi type chart with area to crash.
-                if (opts._type !== CHART_TYPE.AREA && opts._type !== CHART_TYPE.RADAR && !isMultiTypeChart)
-                    if (opts.dataLabelPosition)
-                        strXml += ' <c:dLblPos val="' + opts.dataLabelPosition + '"/>';
+                if (opts.dataLabelPosition)
+                    strXml += ' <c:dLblPos val="' + opts.dataLabelPosition + '"/>';
                 strXml += '    <c:showLegendKey val="0"/>';
                 strXml += '    <c:showVal val="' + (opts.showValue ? '1' : '0') + '"/>';
                 strXml += '    <c:showCatName val="0"/>';


### PR DESCRIPTION
@gitbrent The attached edits should help eliminate repair errors resulting from improperly configured charts. Configurable values are checked against valid options by chart type.

Should resolve errors referenced in:
#788 #768 

Should resolve previously worked around issues for Office Online.

Updates run successfully against all Chart demo's. The only slide change is the Bubble Chart demo on Slide 15, bottom left. The data labels shift from center to right as per default MS Office behaviour. This could be addresses by either tweaking the edit to default this to Center, or update the demo too set the position to center.
