### PR TITLE
Issues #389 - Change Hyperlink Color

### DIFF
--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -973,11 +973,19 @@ function genXmlTextRunProperties(opts: IObjectOptions | ITextOpts, isDefault: bo
 			//runProps += '<a:uFill>'+ genXmlColorSelection('0000FF') +'</a:uFill>'; // Breaks PPT2010! (Issue#74)
 			runProps += `<a:hlinkClick r:id="rId${opts.hyperlink.rId}" invalidUrl="" action="" tgtFrame="" tooltip="${
 				opts.hyperlink.tooltip ? encodeXmlEntities(opts.hyperlink.tooltip) : ''
-			}" history="1" highlightClick="0" endSnd="0"/>`
+			}" history="1" highlightClick="0" endSnd="0"${opts.color?'>':'/>'}`
 		} else if (opts.hyperlink.slide) {
 			runProps += `<a:hlinkClick r:id="rId${opts.hyperlink.rId}" action="ppaction://hlinksldjump" tooltip="${
 				opts.hyperlink.tooltip ? encodeXmlEntities(opts.hyperlink.tooltip) : ''
-			}"/>`
+			}"${opts.color?'>':'/>'}`
+		}
+		if (opts.color) {
+			runProps += '	<a:extLst>'
+			runProps += '		<a:ext uri="{A12FA001-AC4F-418D-AE19-62706E023703}">'
+			runProps += '			<ahyp:hlinkClr xmlns:ahyp="http://schemas.microsoft.com/office/drawing/2018/hyperlinkcolor" val="tx"/>'
+			runProps += '		</a:ext>'
+			runProps += '	</a:extLst>'
+			runProps += '</a:hlinkClick>'
 		}
 	}
 


### PR DESCRIPTION
Adds support for setting the color of a hyperlink text and resolves issues #389 

Tested against demo tests and generates all successfully and error free.

No additional user settings. relies on existing text color options. Sample code below:

```javascript
var slide = pptx.addSlide();

slide.addText(
  [
    { text:'Did You Know?', options:{ fontSize:48, color:pptx.SchemeColor.accent1, breakLine:true } },
    { text:'Hyperlinks', options:{ fontSize:24, breakLine:false, color:'ff0000', hyperlink: { url: "https://github.com/gitbrent/pptxgenjs", tooltip: "Visit Homepage" }
 } },
    { text:' can now be in color', options:{ fontSize:24, color:pptx.SchemeColor.accent6 } }
  ],
  { x:1, y:1, w:'80%', h:1.5, align:'center', fill:pptx.SchemeColor.background2 }
);

slide.addText('Hyperlinks can also be a whole sentence', { fontSize:24, breakLine:false, color:'0fff0f', x:1, y:3, w:'80%', h:1, align:'center', fill:pptx.SchemeColor.background2, 
 hyperlink: { url: "https://github.com/gitbrent/pptxgenjs", tooltip: "Visit Homepage" } }
);

pptx.writeFile('PptxGenJS-Sandbox-'+getTimestamp())
.then(function(fileName){ console.log('Saved! File Name: '+fileName) });
```

Compatibility Note for Keynote: This will not trigger any errors, but hyperlinks will remain default colors due to functional differences.