### PR TITLE
Issues 788+768 - Validate dataLabelPosition is valid for charts

### DIFF
--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -751,10 +751,7 @@ function makeChartType(chartType: CHART_NAME, data: OptsChartData[], opts: IChar
 					strXml += '        </a:defRPr>'
 					strXml += '      </a:pPr></a:p>'
 					strXml += '    </c:txPr>'
-					// Setting dLblPos tag for bar3D seems to break the generated chart
-					if (chartType !== CHART_TYPE.AREA && chartType !== CHART_TYPE.BAR3D) {
-						if (opts.dataLabelPosition) strXml += ' <c:dLblPos val="' + opts.dataLabelPosition + '"/>'
-					}
+					if (opts.dataLabelPosition) strXml += ' <c:dLblPos val="' + opts.dataLabelPosition + '"/>'
 					strXml += '    <c:showLegendKey val="0"/>'
 					strXml += '    <c:showVal val="' + (opts.showValue ? '1' : '0') + '"/>'
 					strXml += '    <c:showCatName val="0"/>'
@@ -888,10 +885,7 @@ function makeChartType(chartType: CHART_NAME, data: OptsChartData[], opts: IChar
 				strXml += '        </a:defRPr>'
 				strXml += '      </a:pPr></a:p>'
 				strXml += '    </c:txPr>'
-				// NOTE: Throwing an error while creating a multi type chart which contains area chart as the below line appears for the other chart type.
-				// Either the given change can be made or the below line can be removed to stop the slide containing multi type chart with area to crash.
-				if (opts._type !== CHART_TYPE.AREA && opts._type !== CHART_TYPE.RADAR && !isMultiTypeChart)
-					if (opts.dataLabelPosition) strXml += ' <c:dLblPos val="' + opts.dataLabelPosition + '"/>'
+				if (opts.dataLabelPosition) strXml += ' <c:dLblPos val="' + opts.dataLabelPosition + '"/>'
 				strXml += '    <c:showLegendKey val="0"/>'
 				strXml += '    <c:showVal val="' + (opts.showValue ? '1' : '0') + '"/>'
 				strXml += '    <c:showCatName val="0"/>'
@@ -1456,7 +1450,7 @@ function makeChartType(chartType: CHART_NAME, data: OptsChartData[], opts: IChar
 				strXml += '   </a:defRPr>'
 				strXml += '      </a:pPr></a:p>'
 				strXml += '    </c:txPr>'
-				if (chartType === CHART_TYPE.PIE) `<c:dLblPos val="${opts.dataLabelPosition || 'inEnd'}"/>`
+				if (chartType === CHART_TYPE.PIE && opts.dataLabelPosition) strXml += `    <c:dLblPos val="${opts.dataLabelPosition}"/>`
 				strXml += '    <c:showLegendKey val="0"/>'
 				strXml += '    <c:showVal val="' + (opts.showValue ? '1' : '0') + '"/>'
 				strXml += '    <c:showCatName val="' + (opts.showLabel ? '1' : '0') + '"/>'

--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -195,17 +195,45 @@ export function addChartDefinition(target: ISlideLib, type: CHART_NAME | IChartM
 
 	// B: Options: misc
 	if (['bar', 'col'].indexOf(options.barDir || '') < 0) options.barDir = 'col'
-	// IMPORTANT: 'bestFit' will cause issues with PPT-Online in some cases, so defualt to 'ctr'!
-	if (['bestFit', 'b', 'ctr', 'inBase', 'inEnd', 'l', 'outEnd', 'r', 't'].indexOf(options.dataLabelPosition || '') < 0)
-		options.dataLabelPosition = options._type === CHART_TYPE.PIE || options._type === CHART_TYPE.DOUGHNUT ? 'bestFit' : 'ctr'
-	options.dataLabelBkgrdColors = options.dataLabelBkgrdColors === true || options.dataLabelBkgrdColors === false ? options.dataLabelBkgrdColors : false
-	if (['b', 'l', 'r', 't', 'tr'].indexOf(options.legendPos || '') < 0) options.legendPos = 'r'
 	// barGrouping: "21.2.3.17 ST_Grouping (Grouping)"
-	if (['clustered', 'standard', 'stacked', 'percentStacked'].indexOf(options.barGrouping || '') < 0) options.barGrouping = 'standard'
-	if (options.barGrouping.indexOf('tacked') > -1) {
-		options.dataLabelPosition = 'ctr' // IMPORTANT: PPT-Online will not open Presentation when 'outEnd' etc is used on stacked!
-		if (!options.barGapWidthPct) options.barGapWidthPct = 50
+	// barGrouping must be handled before data label validation as it can affect valid label positioning
+	if (options._type === CHART_TYPE.AREA) {
+		if (['stacked', 'standard', 'percentStacked'].indexOf(options.barGrouping || '') < 0)
+			options.barGrouping = 'standard';
 	}
+	if (options._type === CHART_TYPE.BAR) {
+        if (['clustered', 'stacked', 'percentStacked'].indexOf(options.barGrouping || '') < 0)
+            options.barGrouping = 'clustered';
+    }
+    if (options._type === CHART_TYPE.BAR3D) {
+            if (['clustered', 'stacked','standard', 'percentStacked'].indexOf(options.barGrouping || '') < 0)
+                options.barGrouping = 'standard';
+    }
+    if (options.barGrouping && options.barGrouping.indexOf('tacked') > -1) {
+        if (!options.barGapWidthPct)
+            options.barGapWidthPct = 50;
+    }
+	// Clean up and validate data label positions
+    // REFERENCE: https://docs.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/e2b1697c-7adc-463d-9081-3daef72f656f?redirectedfrom=MSDN
+    if (options.dataLabelPosition) {
+        if (options._type === CHART_TYPE.AREA || options._type === CHART_TYPE.BAR3D || options._type === CHART_TYPE.DOUGHNUT || options._type === CHART_TYPE.RADAR) delete options.dataLabelPosition 
+        if (options._type === CHART_TYPE.PIE) {
+            if (['bestFit', 'ctr', 'inEnd', 'outEnd'].indexOf(options.dataLabelPosition) < 0) delete options.dataLabelPosition;
+        }
+        if (options._type === CHART_TYPE.BUBBLE || options._type === CHART_TYPE.LINE || options._type === CHART_TYPE.SCATTER) {
+            if (['b', 'ctr', 'l', 'r', 't'].indexOf(options.dataLabelPosition) < 0) delete options.dataLabelPosition;
+        }
+        if (options._type === CHART_TYPE.BAR) {
+            if (['stacked', 'percentStacked'].indexOf(options.barGrouping || '') < 0) {
+                if (['ctr','inBase', 'inEnd'].indexOf(options.dataLabelPosition) < 0) delete options.dataLabelPosition;
+            }
+            if (['clustered'].indexOf(options.barGrouping || '') < 0) {
+                if (['ctr','inBase', 'inEnd','outEnd'].indexOf(options.dataLabelPosition) < 0) delete options.dataLabelPosition;
+            }
+        }
+    }
+    options.dataLabelBkgrdColors = options.dataLabelBkgrdColors === true || options.dataLabelBkgrdColors === false ? options.dataLabelBkgrdColors : false;
+    if (['b', 'l', 'r', 't', 'tr'].indexOf(options.legendPos || '') < 0) options.legendPos = 'r';
 	// 3D bar: ST_Shape
 	if (['cone', 'coneToMax', 'box', 'cylinder', 'pyramid', 'pyramidToMax'].indexOf(options.bar3DShape || '') < 0) options.bar3DShape = 'box'
 	// lineDataSymbol: http://www.datypic.com/sc/ooxml/a-val-32.html


### PR DESCRIPTION
@gitbrent this PR replaces #789 and updates the ./src/*.ts files instead.
(This is a resubmit because of a config issue)

Edits will override user actions with default settings if they try to enter an invalid input for either a dataLabelPosition or barGrouping value. barGrouping affects valid data labels which is why this is included.

This should resolve errors raised in:
#788 #768

It should also resolve issues relating to Office Online usage.

I have removed redundant validation that is no longer required when inserting the dataLabelPosition string

Have built the library through npm scripts > ships and outputted .js file runs successfully against all demo scripts. There is one minor change to bubble chart behaviour as seen in the Bubble Chart demo on Slide 15, bottom left. The data labels shift from center to right as per default MS Office behaviour. This could be addresses by either tweaking the edit to default this to Center, or update the demo too set the position to center depending on how sever you consider this impact.