### PR TITLE
Fix logic for dataLabelFormat code in Pie and Donut charts

### DIFF
--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -276,8 +276,8 @@ export function addChartDefinition(target: ISlideLib, type: CHART_NAME | IChartM
 		options.dataBorder.color = 'F9F9F9'
 	//
 	if (!options.dataLabelFormatCode && options._type === CHART_TYPE.SCATTER) options.dataLabelFormatCode = 'General'
+	if (!options.dataLabelFormatCode && (options._type === CHART_TYPE.PIE || options._type === CHART_TYPE.DOUGHNUT)) options.dataLabelFormatCode = options.showPercent ? '0%' : 'General'
 	options.dataLabelFormatCode = options.dataLabelFormatCode && typeof options.dataLabelFormatCode === 'string' ? options.dataLabelFormatCode : '#,##0'
-	if (options._type === CHART_TYPE.PIE || options._type === CHART_TYPE.DOUGHNUT) options.dataLabelFormatCode = options.showPercent ? '0%' : 'General'
 	//
 	// Set default format for Scatter chart labels to custom string if not defined
 	if (!options.dataLabelFormatScatter && options._type === CHART_TYPE.SCATTER) options.dataLabelFormatScatter = 'custom'


### PR DESCRIPTION
Currently [line 280](https://github.com/gitbrent/PptxGenJS/blame/ba2c5f9b424c7ae61a77f6e9e5a659dfcb1aa59f/src/gen-objects.ts#L280) will overwrite [line 279](https://github.com/gitbrent/PptxGenJS/blame/ba2c5f9b424c7ae61a77f6e9e5a659dfcb1aa59f/src/gen-objects.ts#L279) if the chart type is PIE or DONUT.

What I did was add a conditional check, mimicking the pattern of [line 278](https://github.com/gitbrent/PptxGenJS/blame/ba2c5f9b424c7ae61a77f6e9e5a659dfcb1aa59f/src/gen-objects.ts#L278) to see if `dataLabelFormat` code is set, and I also moved this check up above the non-conditioned `dataLabelFormatCode`.

Fixes https://github.com/gitbrent/PptxGenJS/issues/803