### PR TITLE
Add option to insert soft breaks

### DIFF
--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -255,6 +255,11 @@ export interface TextBaseProps {
 	 */
 	breakLine?: boolean
 	/**
+	 * Add a line-break
+	 * @default false
+	 */
+	softBreakBefore?: boolean
+	/**
 	 * Add standard or custom bullet
 	 * - use `true` for standard bullet
 	 * - pass object options for custom bullet

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -1226,7 +1226,12 @@ export function genXmlTextBody(slideObj: ISlideObject | TableCell): string {
 		// B: Start paragraph, loop over lines and add text runs
 		line.forEach((textObj, idx) => {
 			// A: Set line index
-			textObj.options.lineIdx = idx
+            textObj.options.lineIdx = idx
+            
+            // A.1: Add soft break if not the first run of the line.
+            if (idx > 0 && textObj.options.softBreakBefore) {
+                strSlideXml += `<a:br/>`
+            }
 
 			// B: Inherit pPr-type options from parent shape's `options`
 			textObj.options.align = textObj.options.align || opts.align

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -1226,12 +1226,12 @@ export function genXmlTextBody(slideObj: ISlideObject | TableCell): string {
 		// B: Start paragraph, loop over lines and add text runs
 		line.forEach((textObj, idx) => {
 			// A: Set line index
-            textObj.options.lineIdx = idx
-            
-            // A.1: Add soft break if not the first run of the line.
-            if (idx > 0 && textObj.options.softBreakBefore) {
-                strSlideXml += `<a:br/>`
-            }
+			textObj.options.lineIdx = idx
+
+			// A.1: Add soft break if not the first run of the line.
+			if (idx > 0 && textObj.options.softBreakBefore) {
+				strSlideXml += `<a:br/>`
+			}
 
 			// B: Inherit pPr-type options from parent shape's `options`
 			textObj.options.align = textObj.options.align || opts.align

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1208,6 +1208,11 @@ declare namespace PptxGenJS {
 		 */
 		breakLine?: boolean
 		/**
+		 * Add a line-break
+		 * @default false
+		 */
+		softBreakBefore?: boolean
+		/**
 		 * Add standard or custom bullet
 		 * - use `true` for standard bullet
 		 * - pass object options for custom bullet


### PR DESCRIPTION
Added softBreakBefore to TextOptions it in [src/core-interfaces.ts](https://github.com/memorsolutions/PptxGenJS/blob/a2cd59bc97c899d881a8fdcf594c6572183d8b12/src/core-interfaces.ts#L261)  and [types/index.d.ts](https://github.com/memorsolutions/PptxGenJS/blob/a2cd59bc97c899d881a8fdcf594c6572183d8b12/types/index.d.ts#L1214) along with simple logic in [genXmlTextBody](https://github.com/memorsolutions/PptxGenJS/blob/55f680e4d9f4e7e34059b57ce9e9500a855ef36e/src/gen-xml.ts#L1232) to insert "<a:br/>" if it is set.

Implements #805 