### PR TITLE
Add void return type to addSection definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -84,7 +84,7 @@ declare class PptxGenJS {
 	 * @param {ISectionProps} section - section properties
 	 * @example pptx.addSection({ title:'Charts' });
 	 */
-	addSection(section: PptxGenJS.ISectionProps)
+	addSection(section: PptxGenJS.ISectionProps): void
 	/**
 	 * Add a new Slide to Presentation
 	 * @param {IAddSlideOptions} options - slide options


### PR DESCRIPTION
With latest code from `master` I was getting a type error that a return type was not explicitly set and was defaulting to `any`