### PR TITLE
Fix secondary axis param check

### DIFF
--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -499,7 +499,7 @@ export function makeXmlCharts(rel: ISlideRelChart): string {
 	// B: Axes -----------------------------------------------------------
 	if (rel.opts._type !== CHART_TYPE.PIE && rel.opts._type !== CHART_TYPE.DOUGHNUT) {
 		// Param check
-		if (rel.opts.valAxes && !usesSecondaryValAxis) {
+		if (rel.opts.valAxes && rel.opts.valAxes.length > 1 && !usesSecondaryValAxis) {
 			throw new Error('Secondary axis must be used by one of the multiple charts')
 		}
 


### PR DESCRIPTION
If a secondary axis is not defined in the settings it is possible for multiple charts to use the same val axis.  

This change updates the secondary param check to only throw an exception if a secondary axis is defined.