### PR TITLE
support line spacing by multiple

### DIFF
--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -829,7 +829,14 @@ export interface TextPropsOptions extends PositionProps, DataOrPathProps, TextBa
 	inset?: number
 	isTextBox?: boolean
 	line?: ShapeLineProps
+	/**
+	 * line spacing by pt. e.g.: 28 means 28pt
+	 */
 	lineSpacing?: number
+	/**
+	 * line spacing by multiple. e.g.: 1.2
+	 */
+	lineSpacingMultiple?: number
 	margin?: Margin
 	outline?: { color: Color; size: number }
 	paraSpaceAfter?: number

--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -946,6 +946,7 @@ export function addTextDefinition(target: PresSlide, text: string | TextProps[],
 
 		// C
 		newObject.options.lineSpacing = opt.lineSpacing && !isNaN(opt.lineSpacing) ? opt.lineSpacing : null
+		newObject.options.lineSpacingMultiple = opt.lineSpacingMultiple && !isNaN(opt.lineSpacingMultiple) ? opt.lineSpacingMultiple : null
 
 		// D: Transform text options to bodyProperties as thats how we build XML
 		newObject.options._bodyProp.autoFit = opt.autoFit || false // @deprecated (3.3.0) If true, shape will collapse to text size (Fit To shape)

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -850,7 +850,11 @@ function genXmlParagraphProperties(textObj: ISlideObject | TextProps, isDefault:
 			}
 		}
 
-		if (textObj.options.lineSpacing) strXmlLnSpc = `<a:lnSpc><a:spcPts val="${textObj.options.lineSpacing * 100}"/></a:lnSpc>`
+		if (textObj.options.lineSpacing) {
+			strXmlLnSpc = `<a:lnSpc><a:spcPts val="${Math.round(textObj.options.lineSpacing * 100)}"/></a:lnSpc>`
+		} else if (textObj.options.lineSpacingMultiple) {
+			strXmlLnSpc = `<a:lnSpc><a:spcPct val="${Math.round(textObj.options.lineSpacingMultiple * 100000)}"/></a:lnSpc>`
+		}
 
 		// OPTION: indent
 		if (textObj.options.indentLevel && !isNaN(Number(textObj.options.indentLevel)) && textObj.options.indentLevel > 0) {
@@ -1235,6 +1239,7 @@ export function genXmlTextBody(slideObj: ISlideObject | TableCell): string {
 			// B: Inherit pPr-type options from parent shape's `options`
 			textObj.options.align = textObj.options.align || opts.align
 			textObj.options.lineSpacing = textObj.options.lineSpacing || opts.lineSpacing
+			textObj.options.lineSpacingMultiple = textObj.options.lineSpacingMultiple || opts.lineSpacingMultiple
 			textObj.options.indentLevel = textObj.options.indentLevel || opts.indentLevel
 			textObj.options.paraSpaceBefore = textObj.options.paraSpaceBefore || opts.paraSpaceBefore
 			textObj.options.paraSpaceAfter = textObj.options.paraSpaceAfter || opts.paraSpaceAfter

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1609,7 +1609,14 @@ declare namespace PptxGenJS {
 		inset?: number
 		isTextBox?: boolean
 		line?: ShapeLineProps
+		/**
+		 * line spacing by pt. e.g.: 28 means 28pt
+		 */
 		lineSpacing?: number
+		/**
+		 * line spacing by multiple. e.g.: 1.2
+		 */
+		lineSpacingMultiple?: number
 		margin?: Margin
 		outline?: { color: Color; size: number }
 		paraSpaceAfter?: number


### PR DESCRIPTION
update`TextPropsOptions`

```typescript
interface TextPropsOptions {
	/**
	 * line spacing by pt. e.g.: 28 means 28pt
	 */
	lineSpacing?: number
	/**
	 * line spacing by multiple. e.g.: 1.2
	 */
	lineSpacingMultiple?: number
}
```