### PR TITLE
text run background color (i.e. highlight)

### DIFF
--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -344,6 +344,12 @@ export interface TextBaseProps {
 	 */
 	color?: Color
 	/**
+	 * Highlight color. background for text run.
+	 * - `HexColor`
+	 * @example 'FF0000' // red
+	 */
+	highlight?: HexColor;
+	/**
 	 * Font face name
 	 * @example 'Arial' // Arial font
 	 */

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -954,21 +954,18 @@ function genXmlTextRunProperties(opts: ObjectOptions | TextPropsOptions, isDefau
 	runProps += opts.subscript ? ' baseline="-40000"' : opts.superscript ? ' baseline="30000"' : ''
 	runProps += opts.charSpacing ? ' spc="' + opts.charSpacing * 100 + '" kern="0"' : '' // IMPORTANT: Also disable kerning; otherwise text won't actually expand
 	runProps += ' dirty="0">'
-	// Color / Font / Outline are children of <a:rPr>, so add them now before closing the runProperties tag
+	// Color / Highlight / Font / Outline are children of <a:rPr>, so add them now before closing the runProperties tag
 	if (opts.color || opts.fontFace || opts.outline) {
 		if (opts.outline && typeof opts.outline === 'object') {
 			runProps += `<a:ln w="${valToPts(opts.outline.size || 0.75)}">${genXmlColorSelection(opts.outline.color || 'FFFFFF')}</a:ln>`
 		}
 		if (opts.color) runProps += genXmlColorSelection(opts.color)
+		if (opts.highlight) runProps += `<a:highlight><a:srgbClr val="${opts.highlight}"/></a:highlight>`
 		if (opts.glow) runProps += `<a:effectLst>${createGlowElement(opts.glow, DEF_TEXT_GLOW)}</a:effectLst>`
 		if (opts.fontFace) {
 			// NOTE: 'cs' = Complex Script, 'ea' = East Asian (use "-120" instead of "0" - per Issue #174); ea must come first (Issue #174)
 			runProps += `<a:latin typeface="${opts.fontFace}" pitchFamily="34" charset="0"/><a:ea typeface="${opts.fontFace}" pitchFamily="34" charset="-122"/><a:cs typeface="${opts.fontFace}" pitchFamily="34" charset="-120"/>`
 		}
-	}
-	// highlight
-	if (opts.highlight) {
-		runProps += `<a:highlight><a:srgbClr val="${opts.highlight}"/></a:highlight>`
 	}
 
 	// Hyperlink support

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -966,6 +966,10 @@ function genXmlTextRunProperties(opts: ObjectOptions | TextPropsOptions, isDefau
 			runProps += `<a:latin typeface="${opts.fontFace}" pitchFamily="34" charset="0"/><a:ea typeface="${opts.fontFace}" pitchFamily="34" charset="-122"/><a:cs typeface="${opts.fontFace}" pitchFamily="34" charset="-120"/>`
 		}
 	}
+	// highlight
+	if (opts.highlight) {
+		runProps += `<a:highlight><a:srgbClr val="${opts.highlight}"/></a:highlight>`
+	}
 
 	// Hyperlink support
 	if (opts.hyperlink) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1160,6 +1160,12 @@ declare namespace PptxGenJS {
 		 */
 		color?: Color
 		/**
+		 * Highlight color. background for text run.
+		 * - `HexColor`
+		 * @example 'FF0000' // red
+		 */
+		highlight?: HexColor;
+		/**
 		 * Font face name
 		 * @example 'Arial' // Arial font
 		 */


### PR DESCRIPTION

Mac has this option. Windows do not has this option. But highlight works for windows.

![image](https://user-images.githubusercontent.com/11853824/96703205-27136680-13c5-11eb-9a55-2baca86caa98.png)

![image](https://user-images.githubusercontent.com/11853824/96703477-76599700-13c5-11eb-807f-baa54a3e081a.png)
