### PR TITLE
Custom geometry support (freeform)

### DIFF
--- a/demos/common/demos.js
+++ b/demos/common/demos.js
@@ -2662,6 +2662,15 @@ function genSlides_Shape(pptx) {
 	slide.addShape(pptx.shapes.RIGHT_TRIANGLE, { x: 0.4, y: 4.3, w: 6.0, h: 3.0, fill: { color: '0088CC' }, line: { color: '000000', width: 3 }, shapeName:'First Right Triangle' });
 	slide.addShape(pptx.shapes.RIGHT_TRIANGLE, { x: 7.0, y: 4.3, w: 6.0, h: 3.0, fill: { color: '0088CC' }, line: { color: '000000', width: 2 }, flipH: true });
 
+	slide.addShape(pptx.shapes.CUSTOM_GEOMETRY, { x:10 , y:0.8, w:3.0, h:1.5, fill:{color:'00FF00'}, line:'000000', lineSize:1,
+		points: [
+			{ x: 0, y: 0.75 }, { x: 0.5, y: 0 }, { x: 1, y: 0.3 }, { x: 1.5, y: 0 }, { x: 2, y: 0.3 }, { x: 2.5, y: 0.2 }, { x: 3, y: 0.1 },
+			{ curve: { type:'arc', hR: 0.5, wR: 0.5, stAng: 0, swAng: 90 } },
+			{ x: 0.5, y: 1.5, curve: { type:'quadratic', x1: 2.5, y1: 1.7 } },
+			{ close: true }
+		] 
+	});
+
 	// SLIDE 2: Misc Shape Types with Text
 	// ======== -----------------------------------------------------------------------------------
 	var slide = pptx.addSlide({sectionTitle:'Shapes'});
@@ -2683,6 +2692,15 @@ function genSlides_Shape(pptx) {
 	//
 	slide.addText('RIGHT-TRIANGLE', { shape: pptx.shapes.RIGHT_TRIANGLE, align: 'center', x: 0.4, y: 4.3, w: 6, h: 3, fill: { color: '0088CC' }, line: { color: '000000', width: 3 } });
 	slide.addText('HYPERLINK-SHAPE', { shape: pptx.shapes.RIGHT_TRIANGLE, align: 'center', x: 7.0, y: 4.3, w: 6, h: 3, fill: { color: '0088CC' }, line: { color: '000000', width: 2 }, flipH: true, hyperlink: { url: "https://github.com/gitbrent/pptxgenjs", tooltip: "Visit Homepage" }, });
+
+	slide.addText('CUSTOM-GEOMETRY', { shape: pptx.shapes.CUSTOM_GEOMETRY, x:10 , y:0.8, w:3.0, h:1.5, fill:{color:'00FF00'}, line:'000000', lineSize:1,
+		points: [
+			{ x: 0, y: 0.75 }, { x: 0.5, y: 0 }, { x: 1, y: 0.3 }, { x: 1.5, y: 0 }, { x: 2, y: 0.3 }, { x: 2.5, y: 0.2 }, { x: 3, y: 0.1 },
+			{ curve: { type:'arc', hR: 0.5, wR: 0.5, stAng: 0, swAng: 90 } },
+			{ x: 0.5, y: 1.5, curve: { type:'quadratic', x1: 2.5, y1: 1.7 } },
+			{ close: true }
+		] 
+	});
 }
 
 function genSlides_Text(pptx) {

--- a/src/core-enums.ts
+++ b/src/core-enums.ts
@@ -163,6 +163,7 @@ export enum ShapeType {
 	'curvedLeftArrow' = 'curvedLeftArrow',
 	'curvedRightArrow' = 'curvedRightArrow',
 	'curvedUpArrow' = 'curvedUpArrow',
+	'custGeom' = 'custGeom',
 	'decagon' = 'decagon',
 	'diagStripe' = 'diagStripe',
 	'diamond' = 'diamond',
@@ -357,6 +358,7 @@ export enum SHAPE_TYPE {
 	CURVED_RIGHT_ARROW = 'curvedRightArrow',
 	CURVED_UP_ARROW = 'curvedUpArrow',
 	CURVED_UP_RIBBON = 'ellipseRibbon2',
+	CUSTOM_GEOMETRY = 'custGeom',
 	DECAGON = 'decagon',
 	DIAGONAL_STRIPE = 'diagStripe',
 	DIAMOND = 'diamond',
@@ -534,6 +536,7 @@ export type SHAPE_NAME =
 	| 'cloudCallout'
 	| 'corner'
 	| 'cornerTabs'
+	| 'custGeom'
 	| 'plus'
 	| 'cube'
 	| 'curvedDownArrow'

--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -511,6 +511,16 @@ export interface ShapeProps extends PositionProps {
 	 */
 	line?: ShapeLineProps
 	/**
+	 * Points (only for pptx.shapes.CUSTOM_GEOMETRY)
+	 * @example [{ x: 0, y: 0 }, { x: 10, y: 10 }] //will draw a line between those two points
+	 */
+	points?:
+	Array<{ x: Coord, y: Coord, moveTo?: boolean } |
+	{ x: Coord, y: Coord, curve: { type: 'arc', hR: Coord, wR: Coord, stAng: number, swAng: number } } |
+	{ x: Coord, y: Coord, curve: { type: 'quadratic', x1: Coord, y1: Coord } } |
+	{ x: Coord, y: Coord, curve: { type: 'cubic', x1: Coord, y1: Coord, x2: Coord, y2: Coord } } |
+	{ close: true }>
+	/**
 	 * Radius (only for pptx.shapes.ROUNDED_RECTANGLE)
 	 * - values: 0-180(TODO:values?)
 	 * @default 0


### PR DESCRIPTION
Hello,

This PR adds support for the custGeom shape. (Freehand, custom polygon, path, etc). This solves #597.

I've implemented this by using a similar spec to the one that uses [svg-points](https://github.com/colinmeinke/svg-points).
The path or contour of the custom geometry is declared under the property `points` of the `ShapeProps` object.
With this implementation we are supporting all the custom geometry rules: moveTo, lnTo, arcTo, cubicBezTo, quadBezTo and close.

A translation of an svg path to a custom geometry could be achieved by using the [svg-points package](https://www.npmjs.com/package/svg-points) and adding a custom translation between the arcs.
The svg arc is described by the variables `x, y, rx, ry, xAxisRotation, largeArcFlag and sweepFlag`. On the other side the pptx freeform arc is described by `x, y, hR, wR, stAng, swAng`. 
In order to add some sort of translation between svg-path and a custom geometry points array we should create a translation between those two representations of the arc.

I took the liberty to add an example of a custom geometry inside the Shape Demos section of the demo file.

Hope you like this.
Thank you !