### PR TITLE
fix(#834): Fixed data label corruption bug

### DIFF
--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -1686,7 +1686,7 @@ function makeValAxis(opts: IChartOptsLib, valAxisId: string): string {
 			title: opts.valAxisTitle || 'Axis Title',
 		})
 	}
-	strXml += ' <c:numFmt formatCode="' + (opts.valAxisLabelFormatCode ? opts.valAxisLabelFormatCode : 'General') + '" sourceLinked="0"/>'
+	strXml += `<c:numFmt formatCode='${(opts.valAxisLabelFormatCode ? opts.valAxisLabelFormatCode : "General")}' sourceLinked="0"/>`;
 	if (opts._type === CHART_TYPE.SCATTER) {
 		strXml += '  <c:majorTickMark val="none"/>'
 		strXml += '  <c:minorTickMark val="none"/>'


### PR DESCRIPTION
Fixes #834 

Fixed a bug where using double quotation marks `(" ")` in the
`valAxisLabelFormatCode` property caused the file to be corrupted.

According to _Microsoft_ documentation,
Double quotation marks are required in order to display both text
and numbers in a label. Therefore we enclose these text characters in
double quotation marks `(" ")`.