### PR TITLE
Add transparency to line

### DIFF
--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -474,7 +474,7 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 				// shape Type: LINE: line color
 				if (slideItemObj.options.line) {
 					strSlideXml += slideItemObj.options.line.width ? `<a:ln w="${valToPts(slideItemObj.options.line.width)}">` : '<a:ln>'
-					strSlideXml += genXmlColorSelection(slideItemObj.options.line.color)
+					strSlideXml += genXmlColorSelection(slideItemObj.options.line)
 					if (slideItemObj.options.line.dashType) strSlideXml += `<a:prstDash val="${slideItemObj.options.line.dashType}"/>`
 					if (slideItemObj.options.line.beginArrowType) strSlideXml += `<a:headEnd type="${slideItemObj.options.line.beginArrowType}"/>`
 					if (slideItemObj.options.line.endArrowType) strSlideXml += `<a:tailEnd type="${slideItemObj.options.line.endArrowType}"/>`


### PR DESCRIPTION
Right now there is no way to use `transparency` for `line`:
```js
slide.addShape(pptx.shapes.OVAL_CALLOUT, {
  x: 6,
  y: 2,
  w: 3,
  h: 2,
  fill: { color: "ff0000", transparency: 50 },
  line: { color: "000000", width: 10, transparency: 50 },
});
```

This PR will fix it