### PR TITLE
Add transparency to slide

### DIFF
--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -1031,7 +1031,7 @@ export function addBackgroundDefinition(bkg: BackgroundProps, target: SlideLayou
 			Target: `../media/${(target._name || '').replace(/\s+/gi, '-')}-image-${target._relsMedia.length + 1}.${strImgExtn}`,
 		})
 		target._bkgdImgRid = intRels
-	} else if (bkg && bkg.fill && typeof bkg.fill === 'string') {
+	} else if (bkg && bkg.fill) {
 		target.bkgd = bkg.fill
 	}
 }

--- a/src/gen-utils.ts
+++ b/src/gen-utils.ts
@@ -200,8 +200,8 @@ export function genXmlColorSelection(shapeFill: Color | ShapeFillProps | ShapeLi
 	let internalElements = ''
 	let outText = ''
 
-	if (backColor && typeof backColor === 'string') {
-		outText += `<p:bg><p:bgPr>${genXmlColorSelection(backColor.replace('#', ''))}<a:effectLst/></p:bgPr></p:bg>`
+	if (backColor) {
+		outText += `<p:bg><p:bgPr>${genXmlColorSelection(typeof backColor === 'string' ? backColor.replace('#', '') : backColor)}<a:effectLst/></p:bgPr></p:bg>`
 	}
 
 	if (shapeFill) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -889,7 +889,7 @@ declare namespace PptxGenJS {
 		 * Color (hex format)
 		 * @example 'FF3399'
 		 */
-		fill?: HexColor
+		fill?: HexColor | ShapeFillProps
 	}
 	/**
 	 * Color in Hex format


### PR DESCRIPTION
Fix ability to specify background of slide with colour object.
```js
slide.background = { fill: { color: '909090', transparency: 50 } }
```