### PR TITLE
[DRAFT] feat: add a bullet image

### DIFF
--- a/demos/browser/index.html
+++ b/demos/browser/index.html
@@ -546,7 +546,7 @@
 					+ '// STEP 3: Add any objects to the Slide (charts, tables, shapes, images, etc.)\n'
 					+ "slide.addText(\n"
 					+ "  'BONJOUR - CIAO - GUTEN TAG - HELLO - HOLA - NAMASTE - OLÀ - ZDRAS-TVUY-TE - こんにちは - 你好',\n"
-					+ "  { x:0.0, y:0.25, w:'100%', h:1.5, align:'center', fontSize:24, color:'0088CC', fill:{ color:'F1F1F1' } }\n"
+					+ "  { x:0.0, y:0.25, w:'100%', h:1.5, align:'center', fontSize:24, color:'0088CC', fill:{ color:'F1F1F1' }, bullet: { image: { data: starlabsLogoSml } } }\n"
 					+ ");\n"
 					+ '\n'
 					+ '// STEP 4: Send the PPTX Presentation to the user, using your choice of file name\n'

--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -276,6 +276,12 @@ export interface TextBaseProps {
 				 */
 				characterCode?: string
 				/**
+				 * Bullet image path
+				 * @since v3.5.0-beta
+				 * @example 'image.png'
+				 */
+				image?: ImageProps
+				/**
 				 * Indentation (space between bullet and text) (points)
 				 * @since v3.3.0
 				 * @default 27 // DEF_BULLET_MARGIN
@@ -325,6 +331,10 @@ export interface TextBaseProps {
 				 * @deplrecated v3.3.0 - use `indent`
 				 */
 				marginPt?: number
+				/**
+				 * Rel Id
+				 */
+				relId?: string
 				/**
 				 * Number to start with (only applies to type:number)
 				 * @deprecated v3.3.0 - use `numberStartAt`

--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -983,6 +983,12 @@ export function addTextDefinition(target: PresSlide, text: string | TextProps[],
 	if (typeof text === 'string' || typeof text === 'number') newObject.text = [{ text: text, options: newObject.options }]
 	createHyperlinkRels(target, newObject.text || '')
 
+	// STEP 5: Create image defintion for bullet
+	if (newObject.options.bullet && typeof newObject.options.bullet['image'] === 'object') {
+		newObject.options.bullet['relId'] = getNewRelId(target);
+		addImageDefinition(target, newObject.options.bullet['image']);
+	}
+
 	// LAST: Add object to Slide
 	target._slideObjects.push(newObject)
 }

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -875,10 +875,12 @@ function genXmlParagraphProperties(textObj: ISlideObject | TextProps, isDefault:
 					paragraphPropXml += ` marL="${
 						textObj.options.indentLevel && textObj.options.indentLevel > 0 ? bulletMarL + bulletMarL * textObj.options.indentLevel : bulletMarL
 					}" indent="-${bulletMarL}"`
-					strXmlBullet = `<a:buSzPct val="100000"/><a:buFont typeface="+mj-lt"/><a:buAutoNum type="${textObj.options.bullet.style || 'arabicPeriod'}" startAt="${
+				strXmlBullet = `<a:buSzPct val="100000"/><a:buFont typeface="+mj-lt"/><a:buAutoNum type="${textObj.options.bullet.style || 'arabicPeriod'}" startAt="${
 						textObj.options.bullet.numberStartAt || textObj.options.bullet.startAt || '1'
 					}"/>`
 				}
+			} else if (textObj.options.bullet.image) {
+				strXmlBullet = `<a:buBlip><a:blip r:embed="rId${textObj.options.bullet.relId}"/></a:buBlip>`
 			} else if (textObj.options.bullet.characterCode) {
 				let bulletCode = `&#x${textObj.options.bullet.characterCode};`
 


### PR DESCRIPTION
Hey, this is a draft PR for https://github.com/gitbrent/PptxGenJS/issues/898

Hoping to get some feedback if possible -

My main issue that the image is added to the slide at x:0 and y:0 rather than hiding it. I'm not sure this is the best way to go. What are your thoughts on modifying the addImageDefinition function to create a 'hidden' image? Do you have another suggestion?

It's be great to hear your thoughts

(Ignore the changes to index.html and the typescript hack for now)
