### PR TITLE
Fix genXmlBodyProperties when body type placeholder

### DIFF
--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -1069,7 +1069,7 @@ function genXmlTextRun(textObj: TextProps): string {
 function genXmlBodyProperties(slideObject: ISlideObject | TableCell): string {
 	let bodyProperties = '<a:bodyPr'
 
-	if (slideObject && slideObject._type === SLIDE_OBJECT_TYPES.text && slideObject.options._bodyProp) {
+	if (slideObject && (slideObject._type === SLIDE_OBJECT_TYPES.text || (slideObject._type === SLIDE_OBJECT_TYPES.placeholder && slideObject.options._placeholderType === PLACEHOLDER_TYPES.body)) && slideObject.options._bodyProp) {
 		// PPT-2019 EX: <a:bodyPr wrap="square" lIns="1270" tIns="1270" rIns="1270" bIns="1270" rtlCol="0" anchor="ctr"/>
 
 		// A: Enable or disable textwrapping none or square


### PR DESCRIPTION
Solve #640 

Minimalist test code with `valign`:
```
    const pptx: PptxGenJS = new PptxGenJS();
    pptx.defineSlideMaster({
      objects: [
        {
          placeholder: {
            options: {
              name: 'title',
              type: 'body',
              valign: pptx.AlignV.middle,
              align: pptx.AlignH.center,
              x: 0,
              y: 0,
              w: '100%',
              h: '100%',
            },
          } as any,
        },
      ],
      title: 'testMaster',
    });
    const slide = pptx.addSlide({masterName: 'testMaster'});
    slide.addText('Test Title', {placeholder: 'title'});
    pptx.writeFile({
      fileName: 'test.pptx',
    });
```

result:
![image](https://user-images.githubusercontent.com/5574229/114788725-4989a980-9d82-11eb-9cc7-96f011200db5.png)



