### PR TITLE
Allow specifying a modified theme color

### DIFF
--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -78,7 +78,39 @@ export interface BackgroundProps extends DataOrPathProps, ShapeFillProps {
  */
 export type HexColor = string
 export type ThemeColor = 'tx1' | 'tx2' | 'bg1' | 'bg2' | 'accent1' | 'accent2' | 'accent3' | 'accent4' | 'accent5' | 'accent6'
-export type Color = HexColor | ThemeColor
+export interface ModifiedThemeColor {
+	baseColor: HexColor | ThemeColor
+
+	alpha?: number
+	alphaMod?: number
+	alphaOff?: number
+	blue?: number
+	blueMod?: number
+	blueOff?: number
+	green?: number
+	greenMod?: number
+	greenOff?: number
+	red?: number
+	redMod?: number
+	redOff?: number
+	hue?: number
+	hueMod?: number
+	hueOff?: number
+	lum?: number
+	lumMod?: number
+	lumOff?: number
+	sat?: number
+	satMod?: number
+	satOff?: number
+	shade?: number
+	tint?: number
+
+	comp?: boolean
+	gray?: boolean
+	inv?: boolean
+	gamma?: boolean
+}
+export type Color = HexColor | ThemeColor | ModifiedThemeColor
 export type Margin = number | [number, number, number, number]
 export type HAlign = 'left' | 'center' | 'right' | 'justify'
 export type VAlign = 'top' | 'middle' | 'bottom'
@@ -1016,7 +1048,7 @@ export interface OptsChartGridLine {
 	 * Gridline color (hex)
 	 * @example 'FF3399'
 	 */
-	color?: HexColor
+	color?: Color
 	/**
 	 * Gridline size (points)
 	 */
@@ -1038,7 +1070,7 @@ export interface IChartPropsBase {
 	 */
 	axisPos?: 'b' | 'l' | 'r' | 't'
 	border?: BorderProps
-	chartColors?: HexColor[]
+	chartColors?: Color[]
 	/**
 	 * opacity (0.0 - 1.0)
 	 * @example 0.5 // 50% opaque
@@ -1046,7 +1078,7 @@ export interface IChartPropsBase {
 	chartColorsOpacity?: number
 	dataBorder?: BorderProps
 	displayBlanksAs?: string
-	fill?: HexColor
+	fill?: Color
 	invertedColors?: string
 	lang?: string
 	layout?: PositionProps
@@ -1096,7 +1128,7 @@ export interface IChartPropsAxisCat {
 	catAxisMinVal?: number
 	catAxisOrientation?: 'minMax'
 	catAxisTitle?: string
-	catAxisTitleColor?: string
+	catAxisTitleColor?: Color
 	catAxisTitleFontFace?: string
 	catAxisTitleFontSize?: number
 	catAxisTitleRotate?: number
@@ -1175,7 +1207,7 @@ export interface IChartPropsAxisVal {
 	valAxisMinVal?: number
 	valAxisOrientation?: 'minMax'
 	valAxisTitle?: string
-	valAxisTitleColor?: string
+	valAxisTitleColor?: Color
 	valAxisTitleFontFace?: string
 	valAxisTitleFontSize?: number
 	valAxisTitleRotate?: number
@@ -1267,7 +1299,7 @@ export interface IChartPropsTitle extends TextBaseProps {
 	title?: string
 	titleAlign?: string
 	titleBold?: boolean
-	titleColor?: string
+	titleColor?: Color
 	titleFontFace?: string
 	titleFontSize?: number
 	titlePos?: { x: number; y: number }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -898,7 +898,39 @@ declare namespace PptxGenJS {
 	 */
 	export type HexColor = string
 	export type ThemeColor = 'tx1' | 'tx2' | 'bg1' | 'bg2' | 'accent1' | 'accent2' | 'accent3' | 'accent4' | 'accent5' | 'accent6'
-	export type Color = HexColor | ThemeColor
+	export interface ModifiedThemeColor {
+		baseColor: HexColor | ThemeColor
+
+		alpha?: number
+		alphaMod?: number
+		alphaOff?: number
+		blue?: number
+		blueMod?: number
+		blueOff?: number
+		green?: number
+		greenMod?: number
+		greenOff?: number
+		red?: number
+		redMod?: number
+		redOff?: number
+		hue?: number
+		hueMod?: number
+		hueOff?: number
+		lum?: number
+		lumMod?: number
+		lumOff?: number
+		sat?: number
+		satMod?: number
+		satOff?: number
+		shade?: number
+		tint?: number
+
+		comp?: boolean
+		gray?: boolean
+		inv?: boolean
+		gamma?: boolean
+	}
+	export type Color = HexColor | ThemeColor | ModifiedThemeColor
 	export type Margin = number | [number, number, number, number]
 	export type HAlign = 'left' | 'center' | 'right' | 'justify'
 	export type VAlign = 'top' | 'middle' | 'bottom'
@@ -1793,7 +1825,7 @@ declare namespace PptxGenJS {
 		 * Gridline color (hex)
 		 * @example 'FF3399'
 		 */
-		color?: HexColor
+		color?: Color
 		/**
 		 * Gridline size (points)
 		 */
@@ -1814,7 +1846,7 @@ declare namespace PptxGenJS {
 		 */
 		axisPos?: 'b' | 'l' | 'r' | 't'
 		border?: BorderProps
-		chartColors?: HexColor[]
+		chartColors?: Color[]
 		/**
 		 * opacity (0.0 - 1.0)
 		 * @example 0.5 // 50% opaque
@@ -1822,7 +1854,7 @@ declare namespace PptxGenJS {
 		chartColorsOpacity?: number
 		dataBorder?: BorderProps
 		displayBlanksAs?: string
-		fill?: HexColor
+		fill?: Color
 		invertedColors?: string
 		lang?: string
 		layout?: PositionProps
@@ -1872,7 +1904,7 @@ declare namespace PptxGenJS {
 		catAxisMinVal?: number
 		catAxisOrientation?: 'minMax'
 		catAxisTitle?: string
-		catAxisTitleColor?: string
+		catAxisTitleColor?: Color
 		catAxisTitleFontFace?: string
 		catAxisTitleFontSize?: number
 		catAxisTitleRotate?: number
@@ -1951,7 +1983,7 @@ declare namespace PptxGenJS {
 		valAxisMinVal?: number
 		valAxisOrientation?: 'minMax'
 		valAxisTitle?: string
-		valAxisTitleColor?: string
+		valAxisTitleColor?: Color
 		valAxisTitleFontFace?: string
 		valAxisTitleFontSize?: number
 		valAxisTitleRotate?: number
@@ -2043,7 +2075,7 @@ declare namespace PptxGenJS {
 		title?: string
 		titleAlign?: string
 		titleBold?: boolean
-		titleColor?: string
+		titleColor?: Color
 		titleFontFace?: string
 		titleFontSize?: number
 		titlePos?: { x: number; y: number }


### PR DESCRIPTION
Resolves #953.

This allows specifying all the modifiers that Powerpoint uses internally on theme colors, which is useful when using a powerpoint file as a template for output generated with pptxgenjs.

Haven't updated the docs yet. I wanted to file this draft PR to et any feedback on the design itself first.