### PR TITLE
Fix for `InvertedColors` (Issue #970)

### DIFF
--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -1080,7 +1080,7 @@ export interface IChartPropsBase {
 	dataBorder?: BorderProps
 	displayBlanksAs?: string
 	fill?: HexColor
-	invertedColors?: string
+	invertedColors?: HexColor[]
 	lang?: string
 	layout?: PositionProps
 	shadow?: ShadowProps

--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -795,8 +795,10 @@ function makeChartType(chartType: CHART_NAME, data: OptsChartData[], opts: IChar
 				if (
 					(chartType === CHART_TYPE.BAR || chartType === CHART_TYPE.BAR3D) &&
 					data.length === 1 &&
-					opts.chartColors !== BARCHART_COLORS &&
-					opts.chartColors.length > 1
+					(
+						(opts.chartColors && opts.chartColors !== BARCHART_COLORS && opts.chartColors.length > 1) ||
+						(opts.invertedColors && opts.invertedColors.length)
+					)
 				) {
 					// Series Data Point colors
 					obj.values.forEach((value, index) => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1863,7 +1863,7 @@ declare namespace PptxGenJS {
 		dataBorder?: BorderProps
 		displayBlanksAs?: string
 		fill?: HexColor
-		invertedColors?: string
+		invertedColors?: HexColor[]
 		lang?: string
 		layout?: PositionProps
 		shadow?: ShadowProps


### PR DESCRIPTION
invertedColors should be defined as "HexColor[]";
bar chart did not render inverted colored negative bars unless more than one color was provided in the chartColors array