### PR TITLE
bugfix: each data marker on a doughnut as a different color

### DIFF
--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -1400,7 +1400,7 @@ function makeChartType(chartType: CHART_NAME, data: OptsChartData[], opts: IChar
 
 			// 1: Start Chart
 			strXml += '<c:' + chartType + 'Chart>'
-			strXml += '  <c:varyColors val="0"/>'
+			strXml += '  <c:varyColors val="1"/>'
 			strXml += '<c:ser>'
 			strXml += '  <c:idx val="0"/>'
 			strXml += '  <c:order val="0"/>'


### PR DESCRIPTION
Doughnut charts display a single "Serie 1" label in their legend on
OpenOffice. This is due to `varyColor` (or "Vary Colors By Point") being
set to 0 on them. Since doughnut charts always have one color per
"point" (area), this should always be set to 1 for them.