### PR TITLE
allow chart legend to specify a manual layout

### DIFF
--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -1295,6 +1295,7 @@ export interface IChartPropsLegend {
 	legendFontFace?: string
 	legendFontSize?: number
 	legendPos?: 'b' | 'l' | 'r' | 't' | 'tr'
+	legendLayout?: PositionProps
 }
 export interface IChartPropsTitle extends TextBaseProps {
 	title?: string

--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -581,11 +581,23 @@ export function makeXmlCharts(rel: ISlideRelChart): string {
 		strXml += '</c:plotArea>'
 
 		// OPTION: Legend
-		// IMPORTANT: Dont specify layout to enable auto-fit: PPT does a great job maximizing space with all 4 TRBL locations
+		// RECOMMENDED: Dont specify layout to enable auto-fit: PPT does a great job maximizing space with all 4 TRBL locations
 		if (rel.opts.showLegend) {
 			strXml += '<c:legend>'
-			strXml += '<c:legendPos val="' + rel.opts.legendPos + '"/>'
-			//strXml += '<c:layout/>'
+			if (rel.opts.legendLayout) {
+				strXml += '<c:layout>'
+				strXml += ' <c:manualLayout>'
+				strXml += '  <c:xMode val="edge" />'
+				strXml += '  <c:yMode val="edge" />'
+				strXml += '  <c:x val="' + (rel.opts.legendLayout.x || 0) + '" />'
+				strXml += '  <c:y val="' + (rel.opts.legendLayout.y || 0) + '" />'
+				strXml += '  <c:w val="' + (rel.opts.legendLayout.w || 1) + '" />'
+				strXml += '  <c:h val="' + (rel.opts.legendLayout.h || 0.25) + '" />'
+				strXml += ' </c:manualLayout>'
+				strXml += '</c:layout>'
+			} else {
+				strXml += '<c:legendPos val="' + rel.opts.legendPos + '"/>'
+			}
 			strXml += '<c:overlay val="0"/>'
 			if (rel.opts.legendFontFace || rel.opts.legendFontSize || rel.opts.legendColor) {
 				strXml += '<c:txPr>'


### PR DESCRIPTION
In some cases the automatic legend position from Powerpoint is not very good (it overlaps with the actual chart), thus allowing to specify a legend layout in the same way as chart layout can be specified.