### PR TITLE
allow specifying bar overlap percentage in bar charts

### DIFF
--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -1229,6 +1229,7 @@ export interface IChartPropsChartBar {
 	barGapDepthPct?: number
 	barGapWidthPct?: number
 	barGrouping?: string
+	barOverlapPct?: number
 }
 export interface IChartPropsChartDoughnut {
 	dataNoEffects?: boolean

--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -907,7 +907,7 @@ function makeChartType(chartType: CHART_NAME, data: OptsChartData[], opts: IChar
 			// 4: Add more chart options (gapWidth, line Marker, etc.)
 			if (chartType === CHART_TYPE.BAR) {
 				strXml += '  <c:gapWidth val="' + opts.barGapWidthPct + '"/>'
-				strXml += '  <c:overlap val="' + ((opts.barGrouping || '').indexOf('tacked') > -1 ? 100 : 0) + '"/>'
+				strXml += '  <c:overlap val="' + (opts.barOverlapPct || ((opts.barGrouping || '').indexOf('tacked') > -1 ? 100 : 0)) + '"/>'
 			} else if (chartType === CHART_TYPE.BAR3D) {
 				strXml += '  <c:gapWidth val="' + opts.barGapWidthPct + '"/>'
 				strXml += '  <c:gapDepth val="' + opts.barGapDepthPct + '"/>'


### PR DESCRIPTION
By default bars in a bar chart are stacked together.

![image](https://user-images.githubusercontent.com/449671/141813203-a8712330-159d-42f1-88e6-9b8a14d871f1.png)

There is an option to set them on top of each other, but none to set how far from each other they should be. Powerpoint gives the ability to do so with "Series overlap":

![image](https://user-images.githubusercontent.com/449671/141813532-41c3972e-ba14-474a-875d-7e4c14950af7.png)

With a value of -20% this gives the following:

![image](https://user-images.githubusercontent.com/449671/141813349-dac34cb8-2309-449c-8ec9-90c23a0390c4.png)

Positive values can be used too (+20%):

![image](https://user-images.githubusercontent.com/449671/141813705-3f48fd17-64ab-41ac-ae6d-453faa631b88.png)

The PR adds an option in bar chart options to control this value independently.