### PR TITLE
Image: Add transparency

### DIFF
--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -456,6 +456,12 @@ export interface ImageProps extends PositionProps, DataOrPathProps {
 	 */
 	rounding?: boolean
 	/**
+	 * Transparency (percent)
+	 * - range: 0-100
+	 * @default 0
+	 */
+	transparency?: number
+	/**
 	 * Image sizing options
 	 */
 	sizing?: {

--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -414,6 +414,7 @@ export function addImageDefinition(target: PresSlide, opt: ImageProps) {
 		rotate: opt.rotate || 0,
 		flipV: opt.flipV || false,
 		flipH: opt.flipH || false,
+		transparency: opt.transparency || 0,
 	}
 
 	// STEP 4: Add this image to this Slide Rels (rId/rels count spans all slides! Count all images to get next rId)

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -569,6 +569,7 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 				let imageOpts = slideItemObj.options as ImageProps
 				let sizing = imageOpts.sizing,
 					rounding = imageOpts.rounding,
+					transparency = imageOpts.transparency,
 					width = cx,
 					height = cy
 
@@ -594,6 +595,7 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 					(slide._relsMedia || []).filter(rel => rel.rId === slideItemObj.imageRid)[0]['extn'] === 'svg'
 				) {
 					strSlideXml += '<a:blip r:embed="rId' + (slideItemObj.imageRid - 1) + '">'
+					strSlideXml += ` <a:alphaModFix amt="${Math.round((100 - transparency) * 1000)}"/>`
 					strSlideXml += ' <a:extLst>'
 					strSlideXml += '  <a:ext uri="{96DAC541-7B7A-43D3-8B79-37D633B846F1}">'
 					strSlideXml += '   <asvg:svgBlip xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main" r:embed="rId' + slideItemObj.imageRid + '"/>'
@@ -601,7 +603,9 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 					strSlideXml += ' </a:extLst>'
 					strSlideXml += '</a:blip>'
 				} else {
-					strSlideXml += '<a:blip r:embed="rId' + slideItemObj.imageRid + '"/>'
+					strSlideXml += '<a:blip r:embed="rId' + slideItemObj.imageRid + '">'
+					strSlideXml += ` <a:alphaModFix amt="${Math.round((100 - transparency) * 1000)}"/>`
+					strSlideXml += '</a:blip>'
 				}
 				if (sizing && sizing.type) {
 					let boxW = sizing.w ? getSmartParseNumber(sizing.w, 'X', slide._presLayout) : cx,


### PR DESCRIPTION
Added transparency support for the Image.
Will close https://github.com/gitbrent/PptxGenJS/issues/773

API:
```js
slide.addImage({ data: SVG_BASE64, x: 11.1, y: 5.1, w: 1.5, h: 1.5, transparency: 50 });
```