### PR TITLE
added connected lines for shapes

### DIFF
--- a/demos/modules/demo_shape.mjs
+++ b/demos/modules/demo_shape.mjs
@@ -96,6 +96,7 @@ function genSlide01(pptx) {
 	});
 
 	slide.addShape(pptx.shapes.RIGHT_TRIANGLE, {
+		sId: 20,
 		x: 0.4,
 		y: 4.3,
 		w: 6.0,
@@ -105,6 +106,7 @@ function genSlide01(pptx) {
 		shapeName: "First Right Triangle",
 	});
 	slide.addShape(pptx.shapes.RIGHT_TRIANGLE, {
+		sId: 21,
 		x: 7.0,
 		y: 4.3,
 		w: 6.0,
@@ -113,6 +115,22 @@ function genSlide01(pptx) {
 		line: { color: pptx.colors.ACCENT1, width: 2 },
 		flipH: true,
 	});
+
+	slide.addShape(pptx.shapes.LINE, {
+		x: 3108960,
+		y: 5303520,
+		w: 6035040,
+		h: 0,
+		line: {
+			width: 2, color: "000000",
+			sourceId: 20,
+			targetId: 21,
+			sourceAnchorPos: 5, // on rectangel pptx.anchor.TOP , pptx.anchor.BOTTOM , pptx.anchor.LEFT or pptx.anchor.RIGHT
+			targetAnchorPos: 5 // could be used instead
+		}
+	});
+
+
 }
 
 /**
@@ -251,6 +269,7 @@ function genSlide02(pptx) {
 	slide.addText("RIGHT-TRIANGLE", {
 		shape: pptx.shapes.RIGHT_TRIANGLE,
 		align: "center",
+		sId: 20,
 		x: 0.4,
 		y: 4.3,
 		w: 6,
@@ -261,6 +280,7 @@ function genSlide02(pptx) {
 	slide.addText("HYPERLINK-SHAPE", {
 		shape: pptx.shapes.RIGHT_TRIANGLE,
 		align: "center",
+		sId: 21,
 		x: 7.0,
 		y: 4.3,
 		w: 6,
@@ -270,4 +290,18 @@ function genSlide02(pptx) {
 		flipH: true,
 		hyperlink: { url: "https://github.com/gitbrent/pptxgenjs", tooltip: "Visit Homepage" },
 	});
+	slide.addShape(pptx.shapes.LINE, {
+		x: 3108960,
+		y: 5303520,
+		w: 6035040,
+		h: 0,
+		line: {
+			width: 2, color: "000000",
+			sourceId: 20,
+			targetId: 21,
+			sourceAnchorPos: 5, // on rectangel pptx.anchor.TOP , pptx.anchor.BOTTOM , pptx.anchor.LEFT or pptx.anchor.RIGHT
+			targetAnchorPos: 5 // could be used instead
+		}
+	});
+	slide.addText("Connected lines do not support text", {x:4.5,y:6})
 }

--- a/src/core-enums.ts
+++ b/src/core-enums.ts
@@ -321,6 +321,13 @@ export enum AlignV {
 	'bottom' = 'bottom',
 }
 
+export enum ANCHOR{
+	"TOP" = 0,
+	"LEFT" = 1,
+	"BOTTOM" = 2,
+	"RIGHT" = 3
+}
+
 export enum SHAPE_TYPE {
 	ACTION_BUTTON_BACK_OR_PREVIOUS = 'actionButtonBackPrevious',
 	ACTION_BUTTON_BEGINNING = 'actionButtonBeginning',

--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -16,6 +16,12 @@ import { CHART_NAME, PLACEHOLDER_TYPE, SHAPE_NAME, SLIDE_OBJECT_TYPES, TEXT_HALI
  * @example '75%' // coordinate as percentage of slide size
  */
 export type Coord = number | string
+
+export type IDCoord = {
+	id:number
+	posistion: PositionProps
+}
+
 export type PositionProps = {
 	/**
 	 * Horizontal position
@@ -259,6 +265,10 @@ export interface ShapeLineProps extends ShapeFillProps {
 	 * target shape connection position (dependent on available connection points on a shape)
 	 */
 	targetAnchorPos?: number
+	/**
+	 * adjustments to the curve
+	 */
+	 curveadjust?: number[]
 
 }
 // used by: chart, slide, table, text

--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -238,6 +238,28 @@ export interface ShapeLineProps extends ShapeFillProps {
 	 * @deprecated v3.3.0 - use `width`
 	 */
 	size?: number
+	/**
+	 * Set line shape to be connector
+	 * @default false
+	 */
+	isConnector?: boolean
+	/**
+	 * connected source shape id
+	 */
+	sourceId?: number
+	/**
+	 * connected target shape id
+	 */
+	targetId?: number
+	/**
+	 * source shape connection position (dependent on available connection points on a shape)
+	 */
+	sourceAnchorPos?: number
+	/**
+	 * target shape connection position (dependent on available connection points on a shape)
+	 */
+	targetAnchorPos?: number
+
 }
 // used by: chart, slide, table, text
 export interface TextBaseProps {
@@ -263,80 +285,80 @@ export interface TextBaseProps {
 	 * @default false
 	 */
 	bullet?:
-		| boolean
-		| {
-				/**
-				 * Bullet type
-				 * @default bullet
-				 */
-				type?: 'bullet' | 'number'
-				/**
-				 * Bullet character code (unicode)
-				 * @since v3.3.0
-				 * @example '25BA' // 'BLACK RIGHT-POINTING POINTER' (U+25BA)
-				 */
-				characterCode?: string
-				/**
-				 * Indentation (space between bullet and text) (points)
-				 * @since v3.3.0
-				 * @default 27 // DEF_BULLET_MARGIN
-				 * @example 10 // Indents text 10 points from bullet
-				 */
-				indent?: number
-				/**
-				 * Number type
-				 * @since v3.3.0
-				 * @example 'romanLcParenR' // roman numerals lower-case with paranthesis right
-				 */
-				numberType?:
-					| 'alphaLcParenBoth'
-					| 'alphaLcParenR'
-					| 'alphaLcPeriod'
-					| 'alphaUcParenBoth'
-					| 'alphaUcParenR'
-					| 'alphaUcPeriod'
-					| 'arabicParenBoth'
-					| 'arabicParenR'
-					| 'arabicPeriod'
-					| 'arabicPlain'
-					| 'romanLcParenBoth'
-					| 'romanLcParenR'
-					| 'romanLcPeriod'
-					| 'romanUcParenBoth'
-					| 'romanUcParenR'
-					| 'romanUcPeriod'
-				/**
-				 * Number bullets start at
-				 * @since v3.3.0
-				 * @default 1
-				 * @example 10 // numbered bullets start with 10
-				 */
-				numberStartAt?: number
+	| boolean
+	| {
+		/**
+		 * Bullet type
+		 * @default bullet
+		 */
+		type?: 'bullet' | 'number'
+		/**
+		 * Bullet character code (unicode)
+		 * @since v3.3.0
+		 * @example '25BA' // 'BLACK RIGHT-POINTING POINTER' (U+25BA)
+		 */
+		characterCode?: string
+		/**
+		 * Indentation (space between bullet and text) (points)
+		 * @since v3.3.0
+		 * @default 27 // DEF_BULLET_MARGIN
+		 * @example 10 // Indents text 10 points from bullet
+		 */
+		indent?: number
+		/**
+		 * Number type
+		 * @since v3.3.0
+		 * @example 'romanLcParenR' // roman numerals lower-case with paranthesis right
+		 */
+		numberType?:
+		| 'alphaLcParenBoth'
+		| 'alphaLcParenR'
+		| 'alphaLcPeriod'
+		| 'alphaUcParenBoth'
+		| 'alphaUcParenR'
+		| 'alphaUcPeriod'
+		| 'arabicParenBoth'
+		| 'arabicParenR'
+		| 'arabicPeriod'
+		| 'arabicPlain'
+		| 'romanLcParenBoth'
+		| 'romanLcParenR'
+		| 'romanLcPeriod'
+		| 'romanUcParenBoth'
+		| 'romanUcParenR'
+		| 'romanUcPeriod'
+		/**
+		 * Number bullets start at
+		 * @since v3.3.0
+		 * @default 1
+		 * @example 10 // numbered bullets start with 10
+		 */
+		numberStartAt?: number
 
-				// DEPRECATED
+		// DEPRECATED
 
-				/**
-				 * Bullet code (unicode)
-				 * @deprecated v3.3.0 - use `characterCode`
-				 */
-				code?: string
-				/**
-				 * Margin between bullet and text
-				 * @since v3.2.1
-				 * @deplrecated v3.3.0 - use `indent`
-				 */
-				marginPt?: number
-				/**
-				 * Number to start with (only applies to type:number)
-				 * @deprecated v3.3.0 - use `numberStartAt`
-				 */
-				startAt?: number
-				/**
-				 * Number type
-				 * @deprecated v3.3.0 - use `numberType`
-				 */
-				style?: string
-		  }
+		/**
+		 * Bullet code (unicode)
+		 * @deprecated v3.3.0 - use `characterCode`
+		 */
+		code?: string
+		/**
+		 * Margin between bullet and text
+		 * @since v3.2.1
+		 * @deplrecated v3.3.0 - use `indent`
+		 */
+		marginPt?: number
+		/**
+		 * Number to start with (only applies to type:number)
+		 * @deprecated v3.3.0 - use `numberStartAt`
+		 */
+		startAt?: number
+		/**
+		 * Number type
+		 * @deprecated v3.3.0 - use `numberType`
+		 */
+		style?: string
+	}
 	/**
 	 * Text color
 	 * - `HexColor` or `ThemeColor`
@@ -390,23 +412,23 @@ export interface TextBaseProps {
 	 */
 	underline?: {
 		style?:
-			| 'dash'
-			| 'dashHeavy'
-			| 'dashLong'
-			| 'dashLongHeavy'
-			| 'dbl'
-			| 'dotDash'
-			| 'dotDashHeave'
-			| 'dotDotDash'
-			| 'dotDotDashHeavy'
-			| 'dotted'
-			| 'dottedHeavy'
-			| 'heavy'
-			| 'none'
-			| 'sng'
-			| 'wavy'
-			| 'wavyDbl'
-			| 'wavyHeavy'
+		| 'dash'
+		| 'dashHeavy'
+		| 'dashLong'
+		| 'dashLongHeavy'
+		| 'dbl'
+		| 'dotDash'
+		| 'dotDashHeave'
+		| 'dotDotDash'
+		| 'dotDotDashHeavy'
+		| 'dotted'
+		| 'dottedHeavy'
+		| 'heavy'
+		| 'none'
+		| 'sng'
+		| 'wavy'
+		| 'wavyDbl'
+		| 'wavyHeavy'
 		color?: Color
 	}
 	/**
@@ -632,6 +654,10 @@ export interface ShapeProps extends PositionProps {
 	 * @depreacted v3.3.0
 	 */
 	lineTail?: 'arrow' | 'diamond' | 'none' | 'oval' | 'stealth' | 'triangle'
+	/**
+     * id of shape
+     */
+	sId?: number
 }
 
 // tables =========================================================================================
@@ -1335,20 +1361,20 @@ export interface IChartPropsTitle extends TextBaseProps {
 }
 export interface IChartOpts
 	extends IChartPropsAxisCat,
-		IChartPropsAxisSer,
-		IChartPropsAxisVal,
-		IChartPropsBase,
-		IChartPropsChartBar,
-		IChartPropsChartDoughnut,
-		IChartPropsChartLine,
-		IChartPropsChartPie,
-		IChartPropsChartRadar,
-		IChartPropsDataLabel,
-		IChartPropsDataTable,
-		IChartPropsLegend,
-		IChartPropsTitle,
-		OptsChartGridLine,
-		PositionProps {
+	IChartPropsAxisSer,
+	IChartPropsAxisVal,
+	IChartPropsBase,
+	IChartPropsChartBar,
+	IChartPropsChartDoughnut,
+	IChartPropsChartLine,
+	IChartPropsChartPie,
+	IChartPropsChartRadar,
+	IChartPropsDataLabel,
+	IChartPropsDataTable,
+	IChartPropsLegend,
+	IChartPropsTitle,
+	OptsChartGridLine,
+	PositionProps {
 	/**
 	 * Alt Text value ("How would you describe this object and its contents to someone who is blind?")
 	 * - PowerPoint: [right-click on a chart] > "Edit Alt Text..."
@@ -1487,15 +1513,15 @@ export interface SlideMasterProps {
 		| { rect: {} }
 		| { text: TextProps }
 		| {
-				placeholder: {
-					options: PlaceholderProps
-					/**
-					 * Text to be shown in placeholder (shown until user focuses textbox or adds text)
-					 * - Leave blank to have powerpoint show default phrase (ex: "Click to add title")
-					 */
-					text?: string
-				}
-		  }
+			placeholder: {
+				options: PlaceholderProps
+				/**
+				 * Text to be shown in placeholder (shown until user focuses textbox or adds text)
+				 * - Leave blank to have powerpoint show default phrase (ex: "Click to add title")
+				 */
+				text?: string
+			}
+		}
 	)[]
 	slideNumber?: SlideNumberProps
 

--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -645,6 +645,7 @@ export function addShapeDefinition(target: PresSlide, shapeName: SHAPE_NAME, opt
 		sourceAnchorPos: options.line.sourceAnchorPos || (options.line.sourceAnchorPos === 0 ? 0 : null),
 		targetAnchorPos: options.line.targetAnchorPos || (options.line.targetAnchorPos === 0 ? 0 : null),
 		isConnector: options.line && (options.line.sourceId != null || options.line.targetId != null),
+		curveadjust: options.line.curveadjust || null
 	}
 	if (typeof options.line === 'object' && options.line.type !== 'none') options.line = newLineOpts
 

--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -640,6 +640,11 @@ export function addShapeDefinition(target: PresSlide, shapeName: SHAPE_NAME, opt
 		dashType: options.line.dashType || 'solid',
 		beginArrowType: options.line.beginArrowType || null,
 		endArrowType: options.line.endArrowType || null,
+		sourceId: options.line.sourceId || null,
+		targetId: options.line.targetId || null,
+		sourceAnchorPos: options.line.sourceAnchorPos || (options.line.sourceAnchorPos === 0 ? 0 : null),
+		targetAnchorPos: options.line.targetAnchorPos || (options.line.targetAnchorPos === 0 ? 0 : null),
+		isConnector: options.line && (options.line.sourceId != null || options.line.targetId != null),
 	}
 	if (typeof options.line === 'object' && options.line.type !== 'none') options.line = newLineOpts
 

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+	ANCHOR,
 	BULLET_TYPES,
 	CRLF,
 	DEF_BULLET_MARGIN,
@@ -18,6 +19,7 @@ import {
 } from './core-enums'
 import {
 	IChartOpts,
+	IDCoord,
 	ImageProps,
 	IPresentationProps,
 	ISlideObject,
@@ -80,6 +82,23 @@ let imageSizingXml = {
 }
 
 /**
+ * this function finds the elements of a list based on its id
+ * it is only really used for finding shapes in the coordinates list
+ * this is so the program can caluclate the posistion of connecting lines by itself
+ * @param {IDCoord[]} list 
+ * @param {number} id 
+ */
+
+function FindById(list: IDCoord[], id: number): IDCoord {
+	for (const element of list) {
+		if (element.id == id) {
+			return element
+		}
+	}
+	console.error("no element in list matching id")
+}
+
+/**
  * Transforms a slide or slideLayout to resulting XML string - Creates `ppt/slide*.xml`
  * @param {PresSlide|SlideLayout} slideObject - slide object created within createSlideObject
  * @return {string} XML string with <p:cSld> as the root
@@ -104,7 +123,8 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 	strSlideXml += '<p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/>'
 	strSlideXml += '<a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr>'
 
-	let IDs = []
+	let IDs: number[] = []
+	let coordinates: IDCoord[] = []
 
 	// STEP 3: Loop over all Slide.data objects and add them to this slide
 	slide._slideObjects.forEach((slideItemObj: ISlideObject, idx: number) => {
@@ -127,6 +147,19 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 		}
 
 
+
+		if (slideItemObj.options != undefined) {
+			coordinates.push({
+				id: IDs.at(-1),
+				posistion: {
+					x: slideItemObj.options.x,
+					y: slideItemObj.options.y,
+					w: slideItemObj.options.w,
+					h: slideItemObj.options.h
+				}
+			})
+		}
+
 		let x = 0,
 			y = 0,
 			cx = getSmartParseNumber('75%', 'X', slide._presLayout),
@@ -148,10 +181,107 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 		// A: Set option vars
 		slideItemObj.options = slideItemObj.options || {}
 
-		if (typeof slideItemObj.options.x !== 'undefined') x = getSmartParseNumber(slideItemObj.options.x, 'X', slide._presLayout)
-		if (typeof slideItemObj.options.y !== 'undefined') y = getSmartParseNumber(slideItemObj.options.y, 'Y', slide._presLayout)
-		if (typeof slideItemObj.options.w !== 'undefined') cx = getSmartParseNumber(slideItemObj.options.w, 'X', slide._presLayout)
-		if (typeof slideItemObj.options.h !== 'undefined') cy = getSmartParseNumber(slideItemObj.options.h, 'Y', slide._presLayout)
+		//calculates the coordinates for connecting lines, only works for squares with number posistions ( so no percentages)
+		if (slideItemObj.options.line != undefined) {
+			if (slideItemObj.options.line.isConnector) {
+				const source = FindById(coordinates, slideItemObj.options.line.sourceId);
+				const target = FindById(coordinates, slideItemObj.options.line.targetId);
+
+
+				let deltaX = 0;
+				let deltaY = 0;
+				//this does not work for triangle because anchorpoint is outside the enum!!!!
+				switch (slideItemObj.options.line.sourceAnchorPos) {
+					case ANCHOR.TOP:
+						deltaX = Number(source.posistion.w) / 2;
+						x = Number(source.posistion.x) + deltaX;
+						y = Number(source.posistion.y)
+						break;
+					case ANCHOR.BOTTOM:
+						deltaX = Number(source.posistion.w) / 2;
+						x = Number(source.posistion.x) + deltaX;
+						deltaY = Number(source.posistion.h)
+						y = Number(source.posistion.y) + deltaY
+						break;
+					case ANCHOR.LEFT:
+						deltaY = Number(source.posistion.h) / 2;
+						y = Number(source.posistion.y) + deltaY;
+						x = Number(source.posistion.x);
+						break;
+					case ANCHOR.RIGHT:
+						deltaY = Number(source.posistion.h) / 2;
+						y = Number(source.posistion.y) + deltaY;
+						deltaX = Number(source.posistion.w)
+						x = Number(source.posistion.x) + deltaX;
+						break;
+				}
+
+				let tx = 0;
+				let ty = 0;
+
+				switch (slideItemObj.options.line.targetAnchorPos) {
+					case ANCHOR.TOP:
+						deltaX = Number(target.posistion.w) / 2;
+						tx = Number(target.posistion.x) + deltaX;
+						ty = Number(target.posistion.y)
+						break;
+					case ANCHOR.BOTTOM:
+						deltaX = Number(target.posistion.w) / 2;
+						tx = Number(target.posistion.x) + deltaX;
+						deltaY = Number(target.posistion.h)
+						ty = Number(target.posistion.y) + deltaY
+						break;
+					case ANCHOR.LEFT:
+						deltaY = Number(target.posistion.h) / 2;
+						ty = Number(target.posistion.y) + deltaY;
+						tx = Number(target.posistion.x);
+						break;
+					case ANCHOR.RIGHT:
+						deltaY = Number(target.posistion.h) / 2;
+						ty = Number(target.posistion.y) + deltaY;
+						deltaX = Number(target.posistion.w)
+						tx = Number(target.posistion.x) + deltaX;
+						break;
+				}
+
+				if (tx > x) {
+					cx = tx - x
+
+					slideItemObj.options.flipH = false;
+				} else {
+					slideItemObj.options.flipH = true;
+					cx = x - tx
+					x = tx;
+				}
+				if (ty > y) {
+					cy = ty - y;
+					slideItemObj.options.flipV = false;
+				} else {
+					cy = y - ty
+					y = ty;
+					slideItemObj.options.flipV = true;
+				}
+
+				x = getSmartParseNumber(x, "X", slide._presLayout);
+				y = getSmartParseNumber(y, "Y", slide._presLayout);
+				cx = getSmartParseNumber(cx, "X", slide._presLayout);
+				cy = getSmartParseNumber(cy, "X", slide._presLayout);
+
+
+			} else {
+				if (typeof slideItemObj.options.x !== 'undefined') x = getSmartParseNumber(slideItemObj.options.x, 'X', slide._presLayout)
+				if (typeof slideItemObj.options.y !== 'undefined') y = getSmartParseNumber(slideItemObj.options.y, 'Y', slide._presLayout)
+				if (typeof slideItemObj.options.w !== 'undefined') cx = getSmartParseNumber(slideItemObj.options.w, 'X', slide._presLayout)
+				if (typeof slideItemObj.options.h !== 'undefined') cy = getSmartParseNumber(slideItemObj.options.h, 'Y', slide._presLayout)
+			}
+		} else {
+			if (typeof slideItemObj.options.x !== 'undefined') x = getSmartParseNumber(slideItemObj.options.x, 'X', slide._presLayout)
+			if (typeof slideItemObj.options.y !== 'undefined') y = getSmartParseNumber(slideItemObj.options.y, 'Y', slide._presLayout)
+			if (typeof slideItemObj.options.w !== 'undefined') cx = getSmartParseNumber(slideItemObj.options.w, 'X', slide._presLayout)
+			if (typeof slideItemObj.options.h !== 'undefined') cy = getSmartParseNumber(slideItemObj.options.h, 'Y', slide._presLayout)
+		}
+
+
 
 		// If using a placeholder then inherit it's position
 		if (placeholderObj) {
@@ -228,7 +358,7 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 				// We have to build an actual grid now
 				/*
 					EX: (A0:rowspan=3, B1:rowspan=2, C1:colspan=2)
-
+	
 					/------|------|------|------\
 					|  A0  |  B0  |  C0  |  D0  |
 					|      |  B1  |  C1  |      |
@@ -440,8 +570,8 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 					strSlideXml += '</p:cNvPr>'
 					//TODO add idx feature
 					strSlideXml += `<p:cNvCxnSpPr> 
-										<a:stCxn id="${slideItemObj.options.line.sourceId }" idx="${slideItemObj.options.line.sourceAnchorPos}" /> 
-										<a:endCxn id="${slideItemObj.options.line.targetId }" idx="${slideItemObj.options.line.targetAnchorPos}" />
+										<a:stCxn id="${slideItemObj.options.line.sourceId}" idx="${slideItemObj.options.line.sourceAnchorPos}" /> 
+										<a:endCxn id="${slideItemObj.options.line.targetId}" idx="${slideItemObj.options.line.targetAnchorPos}" />
 									</p:cNvCxnSpPr>` ;
 					strSlideXml += '<p:nvPr/>'
 					strSlideXml += '</p:nvCxnSpPr><p:spPr>'
@@ -450,9 +580,7 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 					strSlideXml += `<a:ext cx="${cx}" cy="${cy}"/></a:xfrm>`
 
 					strSlideXml += '<a:prstGeom prst="' + slideItemObj.shape + '"><a:avLst>'
-					if (slideItemObj.options.rectRadius) {
-						strSlideXml += `<a:gd name="adj" fmla="val ${Math.round((slideItemObj.options.rectRadius * EMU * 100000) / Math.min(cx, cy))}"/>`
-					} else if (slideItemObj.options.angleRange) {
+					if (slideItemObj.options.angleRange) {
 						for (let i = 0; i < 2; i++) {
 							const angle = slideItemObj.options.angleRange[i]
 							strSlideXml += `<a:gd name="adj${i + 1}" fmla="val ${convertRotationDegrees(angle)}" />`
@@ -462,6 +590,17 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 							strSlideXml += `<a:gd name="adj3" fmla="val ${Math.round(slideItemObj.options.arcThicknessRatio * 50000)}" />`
 						}
 					}
+
+					if (slideItemObj.options.line.curveadjust) {
+						let i = 1
+						for (const adjustments in slideItemObj.options.line.curveadjust) {
+							strSlideXml += `<a:gd name="adj${i}" fmla="val ${getSmartParseNumber(adjustments, "X", slide._presLayout)}" />`
+							i++
+						}
+
+					}
+
+
 					strSlideXml += '</a:avLst></a:prstGeom>'
 
 

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -104,8 +104,29 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 	strSlideXml += '<p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/>'
 	strSlideXml += '<a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr>'
 
+	let IDs = []
+
 	// STEP 3: Loop over all Slide.data objects and add them to this slide
 	slide._slideObjects.forEach((slideItemObj: ISlideObject, idx: number) => {
+		if (slideItemObj.options != undefined) {
+			if (slideItemObj.options.sId != undefined) {
+				if (IDs.indexOf(slideItemObj.options.sId) > -1) {
+					throw "ID is already in use, object / shape id cannot be the same for multiple objects / shapes";
+				} else {
+					IDs.push(slideItemObj.options.sId);
+				}
+
+			} else {
+				if (IDs.indexOf(idx + 2) > -1) {
+					throw "an sID used matched an automatically generated ID try using a higher number";
+				} else {
+					IDs.push(idx + 2);
+				}
+
+			}
+		}
+
+
 		let x = 0,
 			y = 0,
 			cx = getSmartParseNumber('75%', 'X', slide._presLayout),
@@ -168,9 +189,8 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 					'<p:cNvGraphicFramePr><a:graphicFrameLocks noGrp="1"/></p:cNvGraphicFramePr>' +
 					'  <p:nvPr><p:extLst><p:ext uri="{D42A27DB-BD31-4B8C-83A1-F6EECF244321}"><p14:modId xmlns:p14="http://schemas.microsoft.com/office/powerpoint/2010/main" val="1579011935"/></p:ext></p:extLst></p:nvPr>' +
 					'</p:nvGraphicFramePr>'
-				strXml += `<p:xfrm><a:off x="${x || (x === 0 ? 0 : EMU)}" y="${y || (y === 0 ? 0 : EMU)}"/><a:ext cx="${cx || (cx === 0 ? 0 : EMU)}" cy="${
-					cy || EMU
-				}"/></p:xfrm>`
+				strXml += `<p:xfrm><a:off x="${x || (x === 0 ? 0 : EMU)}" y="${y || (y === 0 ? 0 : EMU)}"/><a:ext cx="${cx || (cx === 0 ? 0 : EMU)}" cy="${cy || EMU
+					}"/></p:xfrm>`
 				strXml += '<a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table"><a:tbl><a:tblPr/>'
 				// + '        <a:tblPr bandRow="1"/>';
 				// TODO: Support banded rows, first/last row, etc.
@@ -217,7 +237,7 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 				*/
 				// A: add _hmerge cell for colspan. should reserve rowspan
 				arrTabRows.forEach(cells => {
-					for (let cIdx = 0; cIdx < cells.length; ) {
+					for (let cIdx = 0; cIdx < cells.length;) {
 						let cell = cells[cIdx]
 						let colspan = cell.options?.colspan
 						let rowspan = cell.options?.rowspan
@@ -256,7 +276,7 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 					else if (slideItemObj.options.cy || slideItemObj.options.h)
 						intRowH = Math.round(
 							(slideItemObj.options.h ? inch2Emu(slideItemObj.options.h) : typeof slideItemObj.options.cy === 'number' ? slideItemObj.options.cy : 1) /
-								arrTabRows.length
+							arrTabRows.length
 						)
 
 					// B: Start row
@@ -289,30 +309,30 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 						let cellOpts = cell.options || ({} as TableCell['options'])
 						cell.options = cellOpts
 
-						// B: Inherit some options from table when cell options dont exist
-						// @see: http://officeopenxml.com/drwTableCellProperties-alignment.php
-						;['align', 'bold', 'border', 'color', 'fill', 'fontFace', 'fontSize', 'margin', 'underline', 'valign'].forEach(name => {
-							if (objTabOpts[name] && !cellOpts[name] && cellOpts[name] !== 0) cellOpts[name] = objTabOpts[name]
-						})
+							// B: Inherit some options from table when cell options dont exist
+							// @see: http://officeopenxml.com/drwTableCellProperties-alignment.php
+							;['align', 'bold', 'border', 'color', 'fill', 'fontFace', 'fontSize', 'margin', 'underline', 'valign'].forEach(name => {
+								if (objTabOpts[name] && !cellOpts[name] && cellOpts[name] !== 0) cellOpts[name] = objTabOpts[name]
+							})
 
 						let cellValign = cellOpts.valign
 							? ' anchor="' +
-							  cellOpts.valign
-									.replace(/^c$/i, 'ctr')
-									.replace(/^m$/i, 'ctr')
-									.replace('center', 'ctr')
-									.replace('middle', 'ctr')
-									.replace('top', 't')
-									.replace('btm', 'b')
-									.replace('bottom', 'b') +
-							  '"'
+							cellOpts.valign
+								.replace(/^c$/i, 'ctr')
+								.replace(/^m$/i, 'ctr')
+								.replace('center', 'ctr')
+								.replace('middle', 'ctr')
+								.replace('top', 't')
+								.replace('btm', 'b')
+								.replace('bottom', 'b') +
+							'"'
 							: ''
 						let fillColor =
 							cell._optImp && cell._optImp.fill && cell._optImp.fill.color
 								? cell._optImp.fill.color
 								: cell._optImp && cell._optImp.fill && typeof cell._optImp.fill === 'string'
-								? cell._optImp.fill
-								: ''
+									? cell._optImp.fill
+									: ''
 						fillColor =
 							fillColor || (cellOpts.fill && cellOpts.fill.color) ? cellOpts.fill.color : cellOpts.fill && typeof cellOpts.fill === 'string' ? cellOpts.fill : ''
 						let cellFill = fillColor ? `<a:solidFill>${createColorElement(fillColor)}</a:solidFill>` : ''
@@ -353,9 +373,8 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 								if (cellOpts.border[obj.idx].type !== 'none') {
 									strXml += `<a:${obj.name} w="${valToPts(cellOpts.border[obj.idx].pt)}" cap="flat" cmpd="sng" algn="ctr">`
 									strXml += `<a:solidFill>${createColorElement(cellOpts.border[obj.idx].color)}</a:solidFill>`
-									strXml += `<a:prstDash val="${
-										cellOpts.border[obj.idx].type === 'dash' ? 'sysDash' : 'solid'
-									}"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/>`
+									strXml += `<a:prstDash val="${cellOpts.border[obj.idx].type === 'dash' ? 'sysDash' : 'solid'
+										}"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/>`
 									strXml += `</a:${obj.name}>`
 								} else {
 									strXml += `<a:${obj.name} w="0" cap="flat" cmpd="sng" algn="ctr"><a:noFill/></a:${obj.name}>`
@@ -388,113 +407,48 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 
 			case SLIDE_OBJECT_TYPES.text:
 			case SLIDE_OBJECT_TYPES.placeholder:
-				let shapeName = slideItemObj.options.shapeName ? encodeXmlEntities(slideItemObj.options.shapeName) : `Object${idx + 1}`
+				if (slideItemObj.options.line.isConnector) {
+					let shapeName = slideItemObj.options.shapeName ? encodeXmlEntities(slideItemObj.options.shapeName) : `Object${idx + 1}`
 
-				// Lines can have zero cy, but text should not
-				if (!slideItemObj.options.line && cy === 0) cy = EMU * 0.3
+					// Lines can have zero cy, but text should not
+					if (!slideItemObj.options.line && cy === 0) cy = EMU * 0.3
 
-				// Margin/Padding/Inset for textboxes
-				if (!slideItemObj.options._bodyProp) slideItemObj.options._bodyProp = {}
-				if (slideItemObj.options.margin && Array.isArray(slideItemObj.options.margin)) {
-					slideItemObj.options._bodyProp.lIns = valToPts(slideItemObj.options.margin[0] || 0)
-					slideItemObj.options._bodyProp.rIns = valToPts(slideItemObj.options.margin[1] || 0)
-					slideItemObj.options._bodyProp.bIns = valToPts(slideItemObj.options.margin[2] || 0)
-					slideItemObj.options._bodyProp.tIns = valToPts(slideItemObj.options.margin[3] || 0)
-				} else if (typeof slideItemObj.options.margin === 'number') {
-					slideItemObj.options._bodyProp.lIns = valToPts(slideItemObj.options.margin)
-					slideItemObj.options._bodyProp.rIns = valToPts(slideItemObj.options.margin)
-					slideItemObj.options._bodyProp.bIns = valToPts(slideItemObj.options.margin)
-					slideItemObj.options._bodyProp.tIns = valToPts(slideItemObj.options.margin)
-				}
+					// Margin/Padding/Inset for textboxes
+					if (!slideItemObj.options._bodyProp) slideItemObj.options._bodyProp = {}
+					if (slideItemObj.options.margin && Array.isArray(slideItemObj.options.margin)) {
+						slideItemObj.options._bodyProp.lIns = valToPts(slideItemObj.options.margin[0] || 0)
+						slideItemObj.options._bodyProp.rIns = valToPts(slideItemObj.options.margin[1] || 0)
+						slideItemObj.options._bodyProp.bIns = valToPts(slideItemObj.options.margin[2] || 0)
+						slideItemObj.options._bodyProp.tIns = valToPts(slideItemObj.options.margin[3] || 0)
+					} else if (typeof slideItemObj.options.margin === 'number') {
+						slideItemObj.options._bodyProp.lIns = valToPts(slideItemObj.options.margin)
+						slideItemObj.options._bodyProp.rIns = valToPts(slideItemObj.options.margin)
+						slideItemObj.options._bodyProp.bIns = valToPts(slideItemObj.options.margin)
+						slideItemObj.options._bodyProp.tIns = valToPts(slideItemObj.options.margin)
+					}
 
-				// A: Start SHAPE =======================================================
-				strSlideXml += '<p:sp>'
+					// A: Start SHAPE =======================================================
+					strSlideXml += '<p:cxnSp>'
 
-				// B: The addition of the "txBox" attribute is the sole determiner of if an object is a shape or textbox
-				strSlideXml += `<p:nvSpPr><p:cNvPr id="${idx + 2}" name="${shapeName}">`
-				// <Hyperlink>
-				if (slideItemObj.options.hyperlink && slideItemObj.options.hyperlink.url)
-					strSlideXml +=
-						'<a:hlinkClick r:id="rId' +
-						slideItemObj.options.hyperlink._rId +
-						'" tooltip="' +
-						(slideItemObj.options.hyperlink.tooltip ? encodeXmlEntities(slideItemObj.options.hyperlink.tooltip) : '') +
-						'"/>'
-				if (slideItemObj.options.hyperlink && slideItemObj.options.hyperlink.slide)
-					strSlideXml +=
-						'<a:hlinkClick r:id="rId' +
-						slideItemObj.options.hyperlink._rId +
-						'" tooltip="' +
-						(slideItemObj.options.hyperlink.tooltip ? encodeXmlEntities(slideItemObj.options.hyperlink.tooltip) : '') +
-						'" action="ppaction://hlinksldjump"/>'
-				// </Hyperlink>
-				strSlideXml += '</p:cNvPr>'
-				strSlideXml += '<p:cNvSpPr' + (slideItemObj.options && slideItemObj.options.isTextBox ? ' txBox="1"/>' : '/>')
-				strSlideXml += `<p:nvPr>${slideItemObj._type === 'placeholder' ? genXmlPlaceholder(slideItemObj) : genXmlPlaceholder(placeholderObj)}</p:nvPr>`
-				strSlideXml += '</p:nvSpPr><p:spPr>'
-				strSlideXml += `<a:xfrm${locationAttr}>`
-				strSlideXml += `<a:off x="${x}" y="${y}"/>`
-				strSlideXml += `<a:ext cx="${cx}" cy="${cy}"/></a:xfrm>`
+					// B: The addition of the "txBox" attribute is the sole determiner of if an object is a shape or textbox
+					if (slideItemObj.options.sId != undefined) {
+						strSlideXml += `<p:nvCxnSpPr><p:cNvPr id="${slideItemObj.options.sId}" name="${shapeName}">`
+					}
+					else {
+						strSlideXml += `<p:nvCxnSpPr><p:cNvPr id="${idx + 2}" name="${shapeName}">`
+					}
+					strSlideXml += '</p:cNvPr>'
+					//TODO add idx feature
+					strSlideXml += `<p:cNvCxnSpPr> 
+										<a:stCxn id="${slideItemObj.options.line.sourceId }" idx="${slideItemObj.options.line.sourceAnchorPos}" /> 
+										<a:endCxn id="${slideItemObj.options.line.targetId }" idx="${slideItemObj.options.line.targetAnchorPos}" />
+									</p:cNvCxnSpPr>` ;
+					strSlideXml += '<p:nvPr/>'
+					strSlideXml += '</p:nvCxnSpPr><p:spPr>'
+					strSlideXml += `<a:xfrm${locationAttr}>`
+					strSlideXml += `<a:off x="${x}" y="${y}"/>`
+					strSlideXml += `<a:ext cx="${cx}" cy="${cy}"/></a:xfrm>`
 
-				if (slideItemObj.shape === 'custGeom') {
-					strSlideXml += '<a:custGeom><a:avLst />'
-					strSlideXml += '<a:gdLst>'
-					strSlideXml += '</a:gdLst>'
-					strSlideXml += '<a:ahLst />'
-					strSlideXml += '<a:cxnLst>'
-					strSlideXml += '</a:cxnLst>'
-					strSlideXml += '<a:rect l="l" t="t" r="r" b="b" />'
-
-					strSlideXml += '<a:pathLst>'
-					strSlideXml += `<a:path w="${cx}" h="${cy}">`
-
-					slideItemObj.options.points?.map((point, i) => {
-						if ('curve' in point) {
-							switch (point.curve.type) {
-								case 'arc':
-									strSlideXml += `<a:arcTo hR="${getSmartParseNumber(point.curve.hR, 'Y', slide._presLayout)}" wR="${getSmartParseNumber(
-										point.curve.wR,
-										'X',
-										slide._presLayout
-									)}" stAng="${convertRotationDegrees(point.curve.stAng)}" swAng="${convertRotationDegrees(point.curve.swAng)}" />`
-									break
-								case 'cubic':
-									strSlideXml += `<a:cubicBezTo>
-									<a:pt x="${getSmartParseNumber(point.curve.x1, 'X', slide._presLayout)}" y="${getSmartParseNumber(point.curve.y1, 'Y', slide._presLayout)}" />
-									<a:pt x="${getSmartParseNumber(point.curve.x2, 'X', slide._presLayout)}" y="${getSmartParseNumber(point.curve.y2, 'Y', slide._presLayout)}" />
-									<a:pt x="${getSmartParseNumber(point.x, 'X', slide._presLayout)}" y="${getSmartParseNumber(point.y, 'Y', slide._presLayout)}" />
-									</a:cubicBezTo>`
-									break
-								case 'quadratic':
-									strSlideXml += `<a:quadBezTo>
-									<a:pt x="${getSmartParseNumber(point.curve.x1, 'X', slide._presLayout)}" y="${getSmartParseNumber(point.curve.y1, 'Y', slide._presLayout)}" />
-									<a:pt x="${getSmartParseNumber(point.x, 'X', slide._presLayout)}" y="${getSmartParseNumber(point.y, 'Y', slide._presLayout)}" />
-									</a:quadBezTo>`
-									break
-								default:
-									break
-							}
-						} else if ('close' in point) {
-							strSlideXml += `<a:close />`
-						} else if (point.moveTo || i === 0) {
-							strSlideXml += `<a:moveTo><a:pt x="${getSmartParseNumber(point.x, 'X', slide._presLayout)}" y="${getSmartParseNumber(
-								point.y,
-								'Y',
-								slide._presLayout
-							)}" /></a:moveTo>`
-						} else {
-							strSlideXml += `<a:lnTo><a:pt x="${getSmartParseNumber(point.x, 'X', slide._presLayout)}" y="${getSmartParseNumber(
-								point.y,
-								'Y',
-								slide._presLayout
-							)}" /></a:lnTo>`
-						}
-					})
-
-					strSlideXml += '</a:path>'
-					strSlideXml += '</a:pathLst>'
-					strSlideXml += '</a:custGeom>'
-				} else {
 					strSlideXml += '<a:prstGeom prst="' + slideItemObj.shape + '"><a:avLst>'
 					if (slideItemObj.options.rectRadius) {
 						strSlideXml += `<a:gd name="adj" fmla="val ${Math.round((slideItemObj.options.rectRadius * EMU * 100000) / Math.min(cx, cy))}"/>`
@@ -509,60 +463,231 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 						}
 					}
 					strSlideXml += '</a:avLst></a:prstGeom>'
-				}
 
-				// Option: FILL
-				strSlideXml += slideItemObj.options.fill ? genXmlColorSelection(slideItemObj.options.fill) : '<a:noFill/>'
 
-				// shape Type: LINE: line color
-				if (slideItemObj.options.line) {
-					strSlideXml += slideItemObj.options.line.width ? `<a:ln w="${valToPts(slideItemObj.options.line.width)}">` : '<a:ln>'
-					if (slideItemObj.options.line.color) strSlideXml += genXmlColorSelection(slideItemObj.options.line)
-					if (slideItemObj.options.line.dashType) strSlideXml += `<a:prstDash val="${slideItemObj.options.line.dashType}"/>`
-					if (slideItemObj.options.line.beginArrowType) strSlideXml += `<a:headEnd type="${slideItemObj.options.line.beginArrowType}"/>`
-					if (slideItemObj.options.line.endArrowType) strSlideXml += `<a:tailEnd type="${slideItemObj.options.line.endArrowType}"/>`
-					// FUTURE: `endArrowSize` < a: headEnd type = "arrow" w = "lg" len = "lg" /> 'sm' | 'med' | 'lg'(values are 1 - 9, making a 3x3 grid of w / len possibilities)
-					strSlideXml += '</a:ln>'
-				}
+					// Option: FILL
+					strSlideXml += slideItemObj.options.fill ? genXmlColorSelection(slideItemObj.options.fill) : '<a:noFill/>'
 
-				// EFFECTS > SHADOW: REF: @see http://officeopenxml.com/drwSp-effects.php
-				if (slideItemObj.options.shadow) {
-					slideItemObj.options.shadow.type = slideItemObj.options.shadow.type || 'outer'
-					slideItemObj.options.shadow.blur = valToPts(slideItemObj.options.shadow.blur || 8)
-					slideItemObj.options.shadow.offset = valToPts(slideItemObj.options.shadow.offset || 4)
-					slideItemObj.options.shadow.angle = Math.round((slideItemObj.options.shadow.angle || 270) * 60000)
-					slideItemObj.options.shadow.opacity = Math.round((slideItemObj.options.shadow.opacity || 0.75) * 100000)
-					slideItemObj.options.shadow.color = slideItemObj.options.shadow.color || DEF_TEXT_SHADOW.color
-
-					strSlideXml += '<a:effectLst>'
-					strSlideXml += '<a:' + slideItemObj.options.shadow.type + 'Shdw sx="100000" sy="100000" kx="0" ky="0" '
-					strSlideXml += ' algn="bl" rotWithShape="0" blurRad="' + slideItemObj.options.shadow.blur + '" '
-					strSlideXml += ' dist="' + slideItemObj.options.shadow.offset + '" dir="' + slideItemObj.options.shadow.angle + '">'
-					strSlideXml += '<a:srgbClr val="' + slideItemObj.options.shadow.color + '">'
-					strSlideXml += '<a:alpha val="' + slideItemObj.options.shadow.opacity + '"/></a:srgbClr>'
-					strSlideXml += '</a:outerShdw>'
-					strSlideXml += '</a:effectLst>'
-				}
-
-				/* TODO: FUTURE: Text wrapping (copied from MS-PPTX export)
-					// Commented out b/c i'm not even sure this works - current code produces text that wraps in shapes and textboxes, so...
-					if ( slideItemObj.options.textWrap ) {
-						strSlideXml += '<a:extLst>'
-									+ '<a:ext uri="{C572A759-6A51-4108-AA02-DFA0A04FC94B}">'
-									+ '<ma14:wrappingTextBoxFlag xmlns:ma14="http://schemas.microsoft.com/office/mac/drawingml/2011/main" val="1"/>'
-									+ '</a:ext>'
-									+ '</a:extLst>';
+					// shape Type: LINE: line color
+					if (slideItemObj.options.line) {
+						strSlideXml += slideItemObj.options.line.width ? `<a:ln w="${valToPts(slideItemObj.options.line.width)}">` : '<a:ln>'
+						if (slideItemObj.options.line.color) strSlideXml += genXmlColorSelection(slideItemObj.options.line)
+						if (slideItemObj.options.line.dashType) strSlideXml += `<a:prstDash val="${slideItemObj.options.line.dashType}"/>`
+						if (slideItemObj.options.line.beginArrowType) strSlideXml += `<a:headEnd type="${slideItemObj.options.line.beginArrowType}"/>`
+						if (slideItemObj.options.line.endArrowType) strSlideXml += `<a:tailEnd type="${slideItemObj.options.line.endArrowType}"/>`
+						// FUTURE: `endArrowSize` < a: headEnd type = "arrow" w = "lg" len = "lg" /> 'sm' | 'med' | 'lg'(values are 1 - 9, making a 3x3 grid of w / len possibilities)
+						strSlideXml += '</a:ln>'
 					}
-					*/
 
-				// B: Close shape Properties
-				strSlideXml += '</p:spPr>'
+					// EFFECTS > SHADOW: REF: @see http://officeopenxml.com/drwSp-effects.php
+					if (slideItemObj.options.shadow) {
+						slideItemObj.options.shadow.type = slideItemObj.options.shadow.type || 'outer'
+						slideItemObj.options.shadow.blur = valToPts(slideItemObj.options.shadow.blur || 8)
+						slideItemObj.options.shadow.offset = valToPts(slideItemObj.options.shadow.offset || 4)
+						slideItemObj.options.shadow.angle = Math.round((slideItemObj.options.shadow.angle || 270) * 60000)
+						slideItemObj.options.shadow.opacity = Math.round((slideItemObj.options.shadow.opacity || 0.75) * 100000)
+						slideItemObj.options.shadow.color = slideItemObj.options.shadow.color || DEF_TEXT_SHADOW.color
 
-				// C: Add formatted text (text body "bodyPr")
-				strSlideXml += genXmlTextBody(slideItemObj)
+						strSlideXml += '<a:effectLst>'
+						strSlideXml += '<a:' + slideItemObj.options.shadow.type + 'Shdw sx="100000" sy="100000" kx="0" ky="0" '
+						strSlideXml += ' algn="bl" rotWithShape="0" blurRad="' + slideItemObj.options.shadow.blur + '" '
+						strSlideXml += ' dist="' + slideItemObj.options.shadow.offset + '" dir="' + slideItemObj.options.shadow.angle + '">'
+						strSlideXml += '<a:srgbClr val="' + slideItemObj.options.shadow.color + '">'
+						strSlideXml += '<a:alpha val="' + slideItemObj.options.shadow.opacity + '"/></a:srgbClr>'
+						strSlideXml += '</a:outerShdw>'
+						strSlideXml += '</a:effectLst>'
+					}
 
-				// LAST: Close SHAPE =======================================================
-				strSlideXml += '</p:sp>'
+					// B: Close shape Properties
+					strSlideXml += '</p:spPr>'
+
+					// C: Add formatted text (text body "bodyPr")
+					strSlideXml += genXmlTextBody(slideItemObj)
+
+					// LAST: Close SHAPE =======================================================
+					strSlideXml += '</p:cxnSp>'
+				} else {
+					let shapeName = slideItemObj.options.shapeName ? encodeXmlEntities(slideItemObj.options.shapeName) : `Object${idx + 1}`
+
+					// Lines can have zero cy, but text should not
+					if (!slideItemObj.options.line && cy === 0) cy = EMU * 0.3
+
+					// Margin/Padding/Inset for textboxes
+					if (!slideItemObj.options._bodyProp) slideItemObj.options._bodyProp = {}
+					if (slideItemObj.options.margin && Array.isArray(slideItemObj.options.margin)) {
+						slideItemObj.options._bodyProp.lIns = valToPts(slideItemObj.options.margin[0] || 0)
+						slideItemObj.options._bodyProp.rIns = valToPts(slideItemObj.options.margin[1] || 0)
+						slideItemObj.options._bodyProp.bIns = valToPts(slideItemObj.options.margin[2] || 0)
+						slideItemObj.options._bodyProp.tIns = valToPts(slideItemObj.options.margin[3] || 0)
+					} else if (typeof slideItemObj.options.margin === 'number') {
+						slideItemObj.options._bodyProp.lIns = valToPts(slideItemObj.options.margin)
+						slideItemObj.options._bodyProp.rIns = valToPts(slideItemObj.options.margin)
+						slideItemObj.options._bodyProp.bIns = valToPts(slideItemObj.options.margin)
+						slideItemObj.options._bodyProp.tIns = valToPts(slideItemObj.options.margin)
+					}
+
+					// A: Start SHAPE =======================================================
+					strSlideXml += '<p:sp>'
+
+					// B: The addition of the "txBox" attribute is the sole determiner of if an object is a shape or textbox
+					if (slideItemObj.options.sId != undefined) {
+						strSlideXml += `<p:nvSpPr><p:cNvPr id="${slideItemObj.options.sId}" name="${shapeName}">`
+					}
+					else {
+						strSlideXml += `<p:nvSpPr><p:cNvPr id="${idx + 2}" name="${shapeName}">`
+					}
+					// <Hyperlink>
+					if (slideItemObj.options.hyperlink && slideItemObj.options.hyperlink.url)
+						strSlideXml +=
+							'<a:hlinkClick r:id="rId' +
+							slideItemObj.options.hyperlink._rId +
+							'" tooltip="' +
+							(slideItemObj.options.hyperlink.tooltip ? encodeXmlEntities(slideItemObj.options.hyperlink.tooltip) : '') +
+							'"/>'
+					if (slideItemObj.options.hyperlink && slideItemObj.options.hyperlink.slide)
+						strSlideXml +=
+							'<a:hlinkClick r:id="rId' +
+							slideItemObj.options.hyperlink._rId +
+							'" tooltip="' +
+							(slideItemObj.options.hyperlink.tooltip ? encodeXmlEntities(slideItemObj.options.hyperlink.tooltip) : '') +
+							'" action="ppaction://hlinksldjump"/>'
+					// </Hyperlink>
+					strSlideXml += '</p:cNvPr>'
+					strSlideXml += '<p:cNvSpPr' + (slideItemObj.options && slideItemObj.options.isTextBox ? ' txBox="1"/>' : '/>')
+					strSlideXml += `<p:nvPr>${slideItemObj._type === 'placeholder' ? genXmlPlaceholder(slideItemObj) : genXmlPlaceholder(placeholderObj)}</p:nvPr>`
+					strSlideXml += '</p:nvSpPr><p:spPr>'
+					strSlideXml += `<a:xfrm${locationAttr}>`
+					strSlideXml += `<a:off x="${x}" y="${y}"/>`
+					strSlideXml += `<a:ext cx="${cx}" cy="${cy}"/></a:xfrm>`
+
+					if (slideItemObj.shape === 'custGeom') {
+						strSlideXml += '<a:custGeom><a:avLst />'
+						strSlideXml += '<a:gdLst>'
+						strSlideXml += '</a:gdLst>'
+						strSlideXml += '<a:ahLst />'
+						strSlideXml += '<a:cxnLst>'
+						strSlideXml += '</a:cxnLst>'
+						strSlideXml += '<a:rect l="l" t="t" r="r" b="b" />'
+
+						strSlideXml += '<a:pathLst>'
+						strSlideXml += `<a:path w="${cx}" h="${cy}">`
+
+						slideItemObj.options.points?.map((point, i) => {
+							if ('curve' in point) {
+								switch (point.curve.type) {
+									case 'arc':
+										strSlideXml += `<a:arcTo hR="${getSmartParseNumber(point.curve.hR, 'Y', slide._presLayout)}" wR="${getSmartParseNumber(
+											point.curve.wR,
+											'X',
+											slide._presLayout
+										)}" stAng="${convertRotationDegrees(point.curve.stAng)}" swAng="${convertRotationDegrees(point.curve.swAng)}" />`
+										break
+									case 'cubic':
+										strSlideXml += `<a:cubicBezTo>
+									<a:pt x="${getSmartParseNumber(point.curve.x1, 'X', slide._presLayout)}" y="${getSmartParseNumber(point.curve.y1, 'Y', slide._presLayout)}" />
+									<a:pt x="${getSmartParseNumber(point.curve.x2, 'X', slide._presLayout)}" y="${getSmartParseNumber(point.curve.y2, 'Y', slide._presLayout)}" />
+									<a:pt x="${getSmartParseNumber(point.x, 'X', slide._presLayout)}" y="${getSmartParseNumber(point.y, 'Y', slide._presLayout)}" />
+									</a:cubicBezTo>`
+										break
+									case 'quadratic':
+										strSlideXml += `<a:quadBezTo>
+									<a:pt x="${getSmartParseNumber(point.curve.x1, 'X', slide._presLayout)}" y="${getSmartParseNumber(point.curve.y1, 'Y', slide._presLayout)}" />
+									<a:pt x="${getSmartParseNumber(point.x, 'X', slide._presLayout)}" y="${getSmartParseNumber(point.y, 'Y', slide._presLayout)}" />
+									</a:quadBezTo>`
+										break
+									default:
+										break
+								}
+							} else if ('close' in point) {
+								strSlideXml += `<a:close />`
+							} else if (point.moveTo || i === 0) {
+								strSlideXml += `<a:moveTo><a:pt x="${getSmartParseNumber(point.x, 'X', slide._presLayout)}" y="${getSmartParseNumber(
+									point.y,
+									'Y',
+									slide._presLayout
+								)}" /></a:moveTo>`
+							} else {
+								strSlideXml += `<a:lnTo><a:pt x="${getSmartParseNumber(point.x, 'X', slide._presLayout)}" y="${getSmartParseNumber(
+									point.y,
+									'Y',
+									slide._presLayout
+								)}" /></a:lnTo>`
+							}
+						})
+
+						strSlideXml += '</a:path>'
+						strSlideXml += '</a:pathLst>'
+						strSlideXml += '</a:custGeom>'
+					} else {
+						strSlideXml += '<a:prstGeom prst="' + slideItemObj.shape + '"><a:avLst>'
+						if (slideItemObj.options.rectRadius) {
+							strSlideXml += `<a:gd name="adj" fmla="val ${Math.round((slideItemObj.options.rectRadius * EMU * 100000) / Math.min(cx, cy))}"/>`
+						} else if (slideItemObj.options.angleRange) {
+							for (let i = 0; i < 2; i++) {
+								const angle = slideItemObj.options.angleRange[i]
+								strSlideXml += `<a:gd name="adj${i + 1}" fmla="val ${convertRotationDegrees(angle)}" />`
+							}
+
+							if (slideItemObj.options.arcThicknessRatio) {
+								strSlideXml += `<a:gd name="adj3" fmla="val ${Math.round(slideItemObj.options.arcThicknessRatio * 50000)}" />`
+							}
+						}
+						strSlideXml += '</a:avLst></a:prstGeom>'
+					}
+
+					// Option: FILL
+					strSlideXml += slideItemObj.options.fill ? genXmlColorSelection(slideItemObj.options.fill) : '<a:noFill/>'
+
+					// shape Type: LINE: line color
+					if (slideItemObj.options.line) {
+						strSlideXml += slideItemObj.options.line.width ? `<a:ln w="${valToPts(slideItemObj.options.line.width)}">` : '<a:ln>'
+						if (slideItemObj.options.line.color) strSlideXml += genXmlColorSelection(slideItemObj.options.line)
+						if (slideItemObj.options.line.dashType) strSlideXml += `<a:prstDash val="${slideItemObj.options.line.dashType}"/>`
+						if (slideItemObj.options.line.beginArrowType) strSlideXml += `<a:headEnd type="${slideItemObj.options.line.beginArrowType}"/>`
+						if (slideItemObj.options.line.endArrowType) strSlideXml += `<a:tailEnd type="${slideItemObj.options.line.endArrowType}"/>`
+						// FUTURE: `endArrowSize` < a: headEnd type = "arrow" w = "lg" len = "lg" /> 'sm' | 'med' | 'lg'(values are 1 - 9, making a 3x3 grid of w / len possibilities)
+						strSlideXml += '</a:ln>'
+					}
+
+					// EFFECTS > SHADOW: REF: @see http://officeopenxml.com/drwSp-effects.php
+					if (slideItemObj.options.shadow) {
+						slideItemObj.options.shadow.type = slideItemObj.options.shadow.type || 'outer'
+						slideItemObj.options.shadow.blur = valToPts(slideItemObj.options.shadow.blur || 8)
+						slideItemObj.options.shadow.offset = valToPts(slideItemObj.options.shadow.offset || 4)
+						slideItemObj.options.shadow.angle = Math.round((slideItemObj.options.shadow.angle || 270) * 60000)
+						slideItemObj.options.shadow.opacity = Math.round((slideItemObj.options.shadow.opacity || 0.75) * 100000)
+						slideItemObj.options.shadow.color = slideItemObj.options.shadow.color || DEF_TEXT_SHADOW.color
+
+						strSlideXml += '<a:effectLst>'
+						strSlideXml += '<a:' + slideItemObj.options.shadow.type + 'Shdw sx="100000" sy="100000" kx="0" ky="0" '
+						strSlideXml += ' algn="bl" rotWithShape="0" blurRad="' + slideItemObj.options.shadow.blur + '" '
+						strSlideXml += ' dist="' + slideItemObj.options.shadow.offset + '" dir="' + slideItemObj.options.shadow.angle + '">'
+						strSlideXml += '<a:srgbClr val="' + slideItemObj.options.shadow.color + '">'
+						strSlideXml += '<a:alpha val="' + slideItemObj.options.shadow.opacity + '"/></a:srgbClr>'
+						strSlideXml += '</a:outerShdw>'
+						strSlideXml += '</a:effectLst>'
+					}
+
+					/* TODO: FUTURE: Text wrapping (copied from MS-PPTX export)
+						// Commented out b/c i'm not even sure this works - current code produces text that wraps in shapes and textboxes, so...
+						if ( slideItemObj.options.textWrap ) {
+							strSlideXml += '<a:extLst>'
+										+ '<a:ext uri="{C572A759-6A51-4108-AA02-DFA0A04FC94B}">'
+										+ '<ma14:wrappingTextBoxFlag xmlns:ma14="http://schemas.microsoft.com/office/mac/drawingml/2011/main" val="1"/>'
+										+ '</a:ext>'
+										+ '</a:extLst>';
+						}
+						*/
+
+					// B: Close shape Properties
+					strSlideXml += '</p:spPr>'
+
+					// C: Add formatted text (text body "bodyPr")
+					strSlideXml += genXmlTextBody(slideItemObj)
+
+					// LAST: Close SHAPE =======================================================
+					strSlideXml += '</p:sp>'
+				}
 				break
 
 			case SLIDE_OBJECT_TYPES.image:
@@ -574,15 +699,17 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 
 				strSlideXml += '<p:pic>'
 				strSlideXml += '  <p:nvPicPr>'
-				strSlideXml += `<p:cNvPr id="${idx + 2}" name="Object ${idx + 1}" descr="${encodeXmlEntities(imageOpts.altText || slideItemObj.image)}">`
+				if (slideItemObj.options.sId != undefined) {
+					strSlideXml += `<p:cNvPr id="${slideItemObj.options.sId}" name="Object ${idx + 1}" descr="${encodeXmlEntities(imageOpts.altText || slideItemObj.image)}">`
+				} else {
+					strSlideXml += `<p:cNvPr id="${idx + 2}" name="Object ${idx + 1}" descr="${encodeXmlEntities(imageOpts.altText || slideItemObj.image)}">`
+				}
 				if (slideItemObj.hyperlink && slideItemObj.hyperlink.url)
-					strSlideXml += `<a:hlinkClick r:id="rId${slideItemObj.hyperlink._rId}" tooltip="${
-						slideItemObj.hyperlink.tooltip ? encodeXmlEntities(slideItemObj.hyperlink.tooltip) : ''
-					}"/>`
+					strSlideXml += `<a:hlinkClick r:id="rId${slideItemObj.hyperlink._rId}" tooltip="${slideItemObj.hyperlink.tooltip ? encodeXmlEntities(slideItemObj.hyperlink.tooltip) : ''
+						}"/>`
 				if (slideItemObj.hyperlink && slideItemObj.hyperlink.slide)
-					strSlideXml += `<a:hlinkClick r:id="rId${slideItemObj.hyperlink._rId}" tooltip="${
-						slideItemObj.hyperlink.tooltip ? encodeXmlEntities(slideItemObj.hyperlink.tooltip) : ''
-					}" action="ppaction://hlinksldjump"/>`
+					strSlideXml += `<a:hlinkClick r:id="rId${slideItemObj.hyperlink._rId}" tooltip="${slideItemObj.hyperlink.tooltip ? encodeXmlEntities(slideItemObj.hyperlink.tooltip) : ''
+						}" action="ppaction://hlinksldjump"/>`
 				strSlideXml += '    </p:cNvPr>'
 				strSlideXml += '    <p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr>'
 				strSlideXml += '    <p:nvPr>' + genXmlPlaceholder(placeholderObj) + '</p:nvPr>'
@@ -683,7 +810,11 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 				let chartOpts = slideItemObj.options as IChartOpts
 				strSlideXml += '<p:graphicFrame>'
 				strSlideXml += ' <p:nvGraphicFramePr>'
-				strSlideXml += `   <p:cNvPr id="${idx + 2}" name="Chart ${idx + 1}" descr="${encodeXmlEntities(chartOpts.altText || '')}"/>`
+				if (slideItemObj.options.sId != undefined) {
+					strSlideXml += `   <p:cNvPr id="${slideItemObj.options.sId}" name="Chart ${idx + 1}" descr="${encodeXmlEntities(chartOpts.altText || '')}"/>`
+				} else {
+					strSlideXml += `   <p:cNvPr id="${idx + 2}" name="Chart ${idx + 1}" descr="${encodeXmlEntities(chartOpts.altText || '')}"/>`
+				}
 				strSlideXml += '   <p:cNvGraphicFramePr/>'
 				strSlideXml += `   <p:nvPr>${genXmlPlaceholder(placeholderObj)}</p:nvPr>`
 				strSlideXml += ' </p:nvGraphicFramePr>'
@@ -812,41 +943,41 @@ function slideObjectRelationsToXml(slide: PresSlide | SlideLayout, defaultRels: 
 				'<Relationship Id="rId' + rel.rId + '" Target="' + rel.Target + '" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesSlide"/>'
 		}
 	})
-	;(slide._relsChart || []).forEach((rel: ISlideRelChart) => {
-		lastRid = Math.max(lastRid, rel.rId)
-		strXml += '<Relationship Id="rId' + rel.rId + '" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="' + rel.Target + '"/>'
-	})
-	;(slide._relsMedia || []).forEach((rel: ISlideRelMedia) => {
-		lastRid = Math.max(lastRid, rel.rId)
-		if (rel.type.toLowerCase().indexOf('image') > -1) {
-			strXml += '<Relationship Id="rId' + rel.rId + '" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="' + rel.Target + '"/>'
-		} else if (rel.type.toLowerCase().indexOf('audio') > -1) {
-			// As media has *TWO* rel entries per item, check for first one, if found add second rel with alt style
-			if (strXml.indexOf(' Target="' + rel.Target + '"') > -1)
-				strXml += '<Relationship Id="rId' + rel.rId + '" Type="http://schemas.microsoft.com/office/2007/relationships/media" Target="' + rel.Target + '"/>'
-			else
-				strXml +=
-					'<Relationship Id="rId' + rel.rId + '" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/audio" Target="' + rel.Target + '"/>'
-		} else if (rel.type.toLowerCase().indexOf('video') > -1) {
-			// As media has *TWO* rel entries per item, check for first one, if found add second rel with alt style
-			if (strXml.indexOf(' Target="' + rel.Target + '"') > -1)
-				strXml += '<Relationship Id="rId' + rel.rId + '" Type="http://schemas.microsoft.com/office/2007/relationships/media" Target="' + rel.Target + '"/>'
-			else
-				strXml +=
-					'<Relationship Id="rId' + rel.rId + '" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/video" Target="' + rel.Target + '"/>'
-		} else if (rel.type.toLowerCase().indexOf('online') > -1) {
-			// As media has *TWO* rel entries per item, check for first one, if found add second rel with alt style
-			if (strXml.indexOf(' Target="' + rel.Target + '"') > -1)
-				strXml += '<Relationship Id="rId' + rel.rId + '" Type="http://schemas.microsoft.com/office/2007/relationships/image" Target="' + rel.Target + '"/>'
-			else
-				strXml +=
-					'<Relationship Id="rId' +
-					rel.rId +
-					'" Target="' +
-					rel.Target +
-					'" TargetMode="External" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/video"/>'
-		}
-	})
+		; (slide._relsChart || []).forEach((rel: ISlideRelChart) => {
+			lastRid = Math.max(lastRid, rel.rId)
+			strXml += '<Relationship Id="rId' + rel.rId + '" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="' + rel.Target + '"/>'
+		})
+		; (slide._relsMedia || []).forEach((rel: ISlideRelMedia) => {
+			lastRid = Math.max(lastRid, rel.rId)
+			if (rel.type.toLowerCase().indexOf('image') > -1) {
+				strXml += '<Relationship Id="rId' + rel.rId + '" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="' + rel.Target + '"/>'
+			} else if (rel.type.toLowerCase().indexOf('audio') > -1) {
+				// As media has *TWO* rel entries per item, check for first one, if found add second rel with alt style
+				if (strXml.indexOf(' Target="' + rel.Target + '"') > -1)
+					strXml += '<Relationship Id="rId' + rel.rId + '" Type="http://schemas.microsoft.com/office/2007/relationships/media" Target="' + rel.Target + '"/>'
+				else
+					strXml +=
+						'<Relationship Id="rId' + rel.rId + '" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/audio" Target="' + rel.Target + '"/>'
+			} else if (rel.type.toLowerCase().indexOf('video') > -1) {
+				// As media has *TWO* rel entries per item, check for first one, if found add second rel with alt style
+				if (strXml.indexOf(' Target="' + rel.Target + '"') > -1)
+					strXml += '<Relationship Id="rId' + rel.rId + '" Type="http://schemas.microsoft.com/office/2007/relationships/media" Target="' + rel.Target + '"/>'
+				else
+					strXml +=
+						'<Relationship Id="rId' + rel.rId + '" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/video" Target="' + rel.Target + '"/>'
+			} else if (rel.type.toLowerCase().indexOf('online') > -1) {
+				// As media has *TWO* rel entries per item, check for first one, if found add second rel with alt style
+				if (strXml.indexOf(' Target="' + rel.Target + '"') > -1)
+					strXml += '<Relationship Id="rId' + rel.rId + '" Type="http://schemas.microsoft.com/office/2007/relationships/image" Target="' + rel.Target + '"/>'
+				else
+					strXml +=
+						'<Relationship Id="rId' +
+						rel.rId +
+						'" Target="' +
+						rel.Target +
+						'" TargetMode="External" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/video"/>'
+			}
+		})
 
 	// STEP 2: Add default rels
 	defaultRels.forEach((rel, idx) => {
@@ -923,12 +1054,10 @@ function genXmlParagraphProperties(textObj: ISlideObject | TextProps, isDefault:
 
 			if (textObj.options.bullet.type) {
 				if (textObj.options.bullet.type.toString().toLowerCase() === 'number') {
-					paragraphPropXml += ` marL="${
-						textObj.options.indentLevel && textObj.options.indentLevel > 0 ? bulletMarL + bulletMarL * textObj.options.indentLevel : bulletMarL
-					}" indent="-${bulletMarL}"`
-					strXmlBullet = `<a:buSzPct val="100000"/><a:buFont typeface="+mj-lt"/><a:buAutoNum type="${textObj.options.bullet.style || 'arabicPeriod'}" startAt="${
-						textObj.options.bullet.numberStartAt || textObj.options.bullet.startAt || '1'
-					}"/>`
+					paragraphPropXml += ` marL="${textObj.options.indentLevel && textObj.options.indentLevel > 0 ? bulletMarL + bulletMarL * textObj.options.indentLevel : bulletMarL
+						}" indent="-${bulletMarL}"`
+					strXmlBullet = `<a:buSzPct val="100000"/><a:buFont typeface="+mj-lt"/><a:buAutoNum type="${textObj.options.bullet.style || 'arabicPeriod'}" startAt="${textObj.options.bullet.numberStartAt || textObj.options.bullet.startAt || '1'
+						}"/>`
 				}
 			} else if (textObj.options.bullet.characterCode) {
 				let bulletCode = `&#x${textObj.options.bullet.characterCode};`
@@ -939,9 +1068,8 @@ function genXmlParagraphProperties(textObj: ISlideObject | TextProps, isDefault:
 					bulletCode = BULLET_TYPES['DEFAULT']
 				}
 
-				paragraphPropXml += ` marL="${
-					textObj.options.indentLevel && textObj.options.indentLevel > 0 ? bulletMarL + bulletMarL * textObj.options.indentLevel : bulletMarL
-				}" indent="-${bulletMarL}"`
+				paragraphPropXml += ` marL="${textObj.options.indentLevel && textObj.options.indentLevel > 0 ? bulletMarL + bulletMarL * textObj.options.indentLevel : bulletMarL
+					}" indent="-${bulletMarL}"`
 				strXmlBullet = '<a:buSzPct val="100000"/><a:buChar char="' + bulletCode + '"/>'
 			} else if (textObj.options.bullet.code) {
 				// @deprecated `bullet.code` v3.3.0
@@ -953,20 +1081,17 @@ function genXmlParagraphProperties(textObj: ISlideObject | TextProps, isDefault:
 					bulletCode = BULLET_TYPES['DEFAULT']
 				}
 
-				paragraphPropXml += ` marL="${
-					textObj.options.indentLevel && textObj.options.indentLevel > 0 ? bulletMarL + bulletMarL * textObj.options.indentLevel : bulletMarL
-				}" indent="-${bulletMarL}"`
+				paragraphPropXml += ` marL="${textObj.options.indentLevel && textObj.options.indentLevel > 0 ? bulletMarL + bulletMarL * textObj.options.indentLevel : bulletMarL
+					}" indent="-${bulletMarL}"`
 				strXmlBullet = '<a:buSzPct val="100000"/><a:buChar char="' + bulletCode + '"/>'
 			} else {
-				paragraphPropXml += ` marL="${
-					textObj.options.indentLevel && textObj.options.indentLevel > 0 ? bulletMarL + bulletMarL * textObj.options.indentLevel : bulletMarL
-				}" indent="-${bulletMarL}"`
+				paragraphPropXml += ` marL="${textObj.options.indentLevel && textObj.options.indentLevel > 0 ? bulletMarL + bulletMarL * textObj.options.indentLevel : bulletMarL
+					}" indent="-${bulletMarL}"`
 				strXmlBullet = `<a:buSzPct val="100000"/><a:buChar char="${BULLET_TYPES['DEFAULT']}"/>`
 			}
 		} else if (textObj.options.bullet === true) {
-			paragraphPropXml += ` marL="${
-				textObj.options.indentLevel && textObj.options.indentLevel > 0 ? bulletMarL + bulletMarL * textObj.options.indentLevel : bulletMarL
-			}" indent="-${bulletMarL}"`
+			paragraphPropXml += ` marL="${textObj.options.indentLevel && textObj.options.indentLevel > 0 ? bulletMarL + bulletMarL * textObj.options.indentLevel : bulletMarL
+				}" indent="-${bulletMarL}"`
 			strXmlBullet = `<a:buSzPct val="100000"/><a:buChar char="${BULLET_TYPES['DEFAULT']}"/>`
 		} else if (textObj.options.bullet === false) {
 			// We only add this when the user explicitely asks for no bullet, otherwise, it can override the master defaults!
@@ -1045,13 +1170,11 @@ function genXmlTextRunProperties(opts: ObjectOptions | TextPropsOptions, isDefau
 		else if (!opts.hyperlink.url && !opts.hyperlink.slide) throw new Error("ERROR: 'hyperlink requires either `url` or `slide`'")
 		else if (opts.hyperlink.url) {
 			//runProps += '<a:uFill>'+ genXmlColorSelection('0000FF') +'</a:uFill>'; // Breaks PPT2010! (Issue#74)
-			runProps += `<a:hlinkClick r:id="rId${opts.hyperlink._rId}" invalidUrl="" action="" tgtFrame="" tooltip="${
-				opts.hyperlink.tooltip ? encodeXmlEntities(opts.hyperlink.tooltip) : ''
-			}" history="1" highlightClick="0" endSnd="0"${opts.color ? '>' : '/>'}`
+			runProps += `<a:hlinkClick r:id="rId${opts.hyperlink._rId}" invalidUrl="" action="" tgtFrame="" tooltip="${opts.hyperlink.tooltip ? encodeXmlEntities(opts.hyperlink.tooltip) : ''
+				}" history="1" highlightClick="0" endSnd="0"${opts.color ? '>' : '/>'}`
 		} else if (opts.hyperlink.slide) {
-			runProps += `<a:hlinkClick r:id="rId${opts.hyperlink._rId}" action="ppaction://hlinksldjump" tooltip="${
-				opts.hyperlink.tooltip ? encodeXmlEntities(opts.hyperlink.tooltip) : ''
-			}"${opts.color ? '>' : '/>'}`
+			runProps += `<a:hlinkClick r:id="rId${opts.hyperlink._rId}" action="ppaction://hlinksldjump" tooltip="${opts.hyperlink.tooltip ? encodeXmlEntities(opts.hyperlink.tooltip) : ''
+				}"${opts.color ? '>' : '/>'}`
 		}
 		if (opts.color) {
 			runProps += '	<a:extLst>'
@@ -1419,7 +1542,7 @@ export function makeXmlContTypes(slides: PresSlide[], slideLayouts: SlideLayout[
 	strXml += '<Default Extension="m4v" ContentType="video/mp4"/>' // NOTE: Hard-Code this extension as it wont be created in loop below (as extn !== type)
 	strXml += '<Default Extension="mp4" ContentType="video/mp4"/>' // NOTE: Hard-Code this extension as it wont be created in loop below (as extn !== type)
 	slides.forEach(slide => {
-		;(slide._relsMedia || []).forEach(rel => {
+		; (slide._relsMedia || []).forEach(rel => {
 			if (rel.type !== 'image' && rel.type !== 'online' && rel.type !== 'chart' && rel.extn !== 'm4v' && strXml.indexOf(rel.type) === -1) {
 				strXml += '<Default Extension="' + rel.extn + '" ContentType="' + rel.type + '"/>'
 			}
@@ -1455,9 +1578,9 @@ export function makeXmlContTypes(slides: PresSlide[], slideLayouts: SlideLayout[
 			'<Override PartName="/ppt/slideLayouts/slideLayout' +
 			(idx + 1) +
 			'.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>'
-		;(layout._relsChart || []).forEach(rel => {
-			strXml += ' <Override PartName="' + rel.Target + '" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>'
-		})
+			; (layout._relsChart || []).forEach(rel => {
+				strXml += ' <Override PartName="' + rel.Target + '" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>'
+			})
 	})
 
 	// STEP 5: Add notes slide(s)

--- a/src/pptxgen.ts
+++ b/src/pptxgen.ts
@@ -76,6 +76,7 @@ import {
 	SchemeColor,
 	ShapeType,
 	WRITE_OUTPUT_TYPE,
+	ANCHOR
 } from './core-enums'
 import {
 	AddSlideProps,
@@ -281,6 +282,10 @@ export default class PptxGenJS implements IPresentationProps {
 	private _shapes = SHAPE_TYPE
 	public get shapes(): typeof SHAPE_TYPE {
 		return this._shapes
+	}
+	private _anchor = ANCHOR
+	public get anchor(): typeof ANCHOR {
+		return this._anchor
 	}
 
 	constructor() {


### PR DESCRIPTION
hi, i am aware of the [other pull request](https://github.com/gitbrent/PptxGenJS/pull/777) by @lifejuggler. But seeing as how that is over a year old i thought i would just contribute again. i have updated some of @lifejugglers code to be able to merge into the newest master branch, and added a bit of a patch solution to id's

```typescript
		if (slideItemObj.options != undefined) {
			if (slideItemObj.options.sId != undefined) {
				if (IDs.indexOf(slideItemObj.options.sId) > -1) {
					throw "ID is already in use, object / shape id cannot be the same for multiple objects / shapes";
				} else {
					IDs.push(slideItemObj.options.sId);
				}

			} else {
				if (IDs.indexOf(idx + 2) > -1) {
					throw "an sID used matched an automatically generated ID try using a higher number";
				} else {
					IDs.push(idx + 2);
				}

			}
		}
```
this at least throws an error if you have colliding id's, however i was wondering you you though it would be smarter to just automatically increment over already taken ids or if functions should return an automatically generated id to the user for them to use.

i also added an anchor enum that works at least for rectangular shapes. and added connectors to the shapes demo, like you asked.

i can also add connectors to other objects like tables or media, but i don't know if that is even somthing that we want?

should the user need to calculate their own position of of the connector arrows, or do we want this functionality built into the library? i can add this feature for squares at least.

i am very willing to help out with development of this feature if you just tell my what you think is best.
 



