### PR TITLE
serie name on bubble chart, category axis position, leader lines on bubble chart

### DIFF
--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -1101,6 +1101,7 @@ export interface IChartPropsBase {
 	showLeaderLines?: boolean
 	showLegend?: boolean
 	showPercent?: boolean
+	showSerName?: boolean,
 	showTitle?: boolean
 	showValue?: boolean
 	/**
@@ -1119,6 +1120,7 @@ export interface IChartPropsAxisCat {
 	 */
 	catAxes?: IChartPropsAxisCat[]
 	catAxisBaseTimeUnit?: string
+	catAxisCrossesAt?: string | number,
 	catAxisHidden?: boolean
 	catAxisLabelColor?: string
 	catAxisLabelFontBold?: boolean

--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -764,7 +764,7 @@ function makeChartType(chartType: CHART_NAME, data: OptsChartData[], opts: IChar
 					strXml += '    <c:showLegendKey val="0"/>'
 					strXml += '    <c:showVal val="' + (opts.showValue ? '1' : '0') + '"/>'
 					strXml += '    <c:showCatName val="0"/>'
-					strXml += '    <c:showSerName val="0"/>'
+					strXml += '    <c:showSerName val="' + (opts.showSerName ? '1' : '0') + '"/>'
 					strXml += '    <c:showPercent val="0"/>'
 					strXml += '    <c:showBubbleSize val="0"/>'
 					strXml += `    <c:showLeaderLines val="${opts.showLeaderLines ? '1' : '0'}"/>`
@@ -909,7 +909,7 @@ function makeChartType(chartType: CHART_NAME, data: OptsChartData[], opts: IChar
 				strXml += '    <c:showLegendKey val="0"/>'
 				strXml += '    <c:showVal val="' + (opts.showValue ? '1' : '0') + '"/>'
 				strXml += '    <c:showCatName val="0"/>'
-				strXml += '    <c:showSerName val="0"/>'
+				strXml += '    <c:showSerName val="' + (opts.showSerName ? '1' : '0') + '"/>'
 				strXml += '    <c:showPercent val="0"/>'
 				strXml += '    <c:showBubbleSize val="0"/>'
 				strXml += `    <c:showLeaderLines val="${opts.showLeaderLines ? '1' : '0'}"/>`
@@ -1126,7 +1126,7 @@ function makeChartType(chartType: CHART_NAME, data: OptsChartData[], opts: IChar
 						strXml += '	<c:showLegendKey val="0"/>'
 						strXml += ` <c:showVal val="${opts.showLabel ? '1' : '0'}"/>`
 						strXml += ` <c:showCatName val="${opts.showLabel ? '1' : '0'}"/>`
-						strXml += '	<c:showSerName val="0"/>'
+						strXml += ` <c:showSerName val="${opts.showSerName ? '1' : '0'}"/>`
 						strXml += '	<c:showPercent val="0"/>'
 						strXml += '	<c:showBubbleSize val="0"/>'
 						strXml += '	<c:extLst>'
@@ -1227,7 +1227,7 @@ function makeChartType(chartType: CHART_NAME, data: OptsChartData[], opts: IChar
 				strXml += '    <c:showLegendKey val="0"/>'
 				strXml += '    <c:showVal val="' + (opts.showValue ? '1' : '0') + '"/>'
 				strXml += '    <c:showCatName val="0"/>'
-				strXml += '    <c:showSerName val="0"/>'
+				strXml += '    <c:showSerName val="' + (opts.showSerName ? '1' : '0') + '"/>'
 				strXml += '    <c:showPercent val="0"/>'
 				strXml += '    <c:showBubbleSize val="0"/>'
 				strXml += '  </c:dLbls>'
@@ -1388,9 +1388,14 @@ function makeChartType(chartType: CHART_NAME, data: OptsChartData[], opts: IChar
 				strXml += '    <c:showLegendKey val="0"/>'
 				strXml += '    <c:showVal val="' + (opts.showValue ? '1' : '0') + '"/>'
 				strXml += '    <c:showCatName val="0"/>'
-				strXml += '    <c:showSerName val="0"/>'
+				strXml += '    <c:showSerName val="' + (opts.showSerName ? '1' : '0') + '"/>'
 				strXml += '    <c:showPercent val="0"/>'
 				strXml += '    <c:showBubbleSize val="0"/>'
+				strXml += '    <c:extLst>'
+				strXml += '      <c:ext uri="{CE6537A1-D6FC-4f65-9D91-7224C49458BB}" xmlns:c15="http://schemas.microsoft.com/office/drawing/2012/chart">'
+				strXml += '        <c15:showLeaderLines val="' + (opts.showLeaderLines ? '1' : '0') + '"/>'
+				strXml += '      </c:ext>'
+				strXml += '    </c:extLst>'
 				strXml += '  </c:dLbls>'
 			}
 
@@ -1490,7 +1495,7 @@ function makeChartType(chartType: CHART_NAME, data: OptsChartData[], opts: IChar
 				strXml += '    <c:showLegendKey val="0"/>'
 				strXml += '    <c:showVal val="' + (opts.showValue ? '1' : '0') + '"/>'
 				strXml += '    <c:showCatName val="' + (opts.showLabel ? '1' : '0') + '"/>'
-				strXml += '    <c:showSerName val="0"/>'
+				strXml += '    <c:showSerName val="' + (opts.showSerName ? '1' : '0') + '"/>'
 				strXml += '    <c:showPercent val="' + (opts.showPercent ? '1' : '0') + '"/>'
 				strXml += '    <c:showBubbleSize val="0"/>'
 				strXml += '  </c:dLbl>'
@@ -1683,8 +1688,6 @@ function makeCatAxis(opts: IChartOptsLib, axisId: string, valAxisId: string): st
 function makeValAxis(opts: IChartOptsLib, valAxisId: string): string {
 	let axisPos = valAxisId === AXIS_ID_VALUE_PRIMARY ? (opts.barDir === 'col' ? 'l' : 'b') : opts.barDir !== 'col' ? 'r' : 't'
 	let strXml = ''
-	let isRight = axisPos === 'r' || axisPos === 't'
-	let crosses = isRight ? 'max' : 'autoZero'
 	let crossAxId = valAxisId === AXIS_ID_VALUE_PRIMARY ? AXIS_ID_CATEGORY_PRIMARY : AXIS_ID_CATEGORY_SECONDARY
 
 	strXml += '<c:valAx>'
@@ -1746,7 +1749,15 @@ function makeValAxis(opts: IChartOptsLib, valAxisId: string): string {
 	strXml += '  </a:p>'
 	strXml += ' </c:txPr>'
 	strXml += ' <c:crossAx val="' + crossAxId + '"/>'
-	strXml += ' <c:crosses val="' + crosses + '"/>'
+	if (typeof opts.catAxisCrossesAt === 'number') {
+		strXml += ' <c:crossesAt val="' + opts.catAxisCrossesAt + '"/>'
+	} else if (typeof opts.catAxisCrossesAt === 'string') {
+		strXml += ' <c:crosses val="' + opts.catAxisCrossesAt + '"/>'
+	} else {
+		let isRight = axisPos === 'r' || axisPos === 't'
+		let crosses = isRight ? 'max' : 'autoZero'
+		strXml += ' <c:crosses val="' + crosses + '"/>'
+	}
 	strXml +=
 		' <c:crossBetween val="' +
 		(opts._type === CHART_TYPE.SCATTER || (Array.isArray(opts._type) && opts._type.filter(type => type.type === CHART_TYPE.AREA).length > 0 ? true : false)


### PR DESCRIPTION
## Ability to add serie name to bubble chart

The goal is to actually display a label aside each bubble. Adding a label per bubble requires generating a lot of XML: adding a new column with label as data, and data references to these labels.

Adding serie name is much easier, only setting a flag. The trick is then to create one serie per bubble: X axis contains the positions of all bubbles, then each serie contains a single value. It also allows setting the color for each bubble, again without complex generation.

| X Axis | Serie 1 | Size 1 | Serie 2 | Size 2 | Serie 3 | Size 3 |
|--------|---------|--------|---------|--------|---------|--------|
| 1.5    | 2.5     | 100    |         |        |         |        |
| 2      |         |        | 1.2     | 50     |         |        |
| 2.3    |         |        |         |        | 3.2     | 75     |

## Category axis position

Values axis can be set at an arbitrary position using `valAxisCrossesAt`, but category axis could not be positioned the same way. Add `catAxisCrossesAt` that behaves the same way to set it, and preserve previous behaviour when not set.

## Leader lines on bubble chart

Leader lines could be enabled by a property, but were not enabled on bubble chart. Those are not displayed by default as Powerpoint judges that when the label is at its default position, then leader line is redundant. But if the label is moved, leader line appears.

## Result

![image](https://user-images.githubusercontent.com/449671/163199105-adc3e91b-9717-4e88-a210-77d66e3ea626.png)
