### PR TITLE
Support bubble 3D chart type

### DIFF
--- a/src/core-enums.ts
+++ b/src/core-enums.ts
@@ -38,7 +38,7 @@ export const AXIS_ID_SERIES_PRIMARY: string = '2094734556'
 
 export type JSZIP_OUTPUT_TYPE = 'arraybuffer' | 'base64' | 'binarystring' | 'blob' | 'nodebuffer' | 'uint8array'
 export type WRITE_OUTPUT_TYPE = JSZIP_OUTPUT_TYPE | 'STREAM'
-export type CHART_NAME = 'area' | 'bar' | 'bar3D' | 'bubble' | 'doughnut' | 'line' | 'pie' | 'radar' | 'scatter'
+export type CHART_NAME = 'area' | 'bar' | 'bar3D' | 'bubble' | 'bubble3D' | 'doughnut' | 'line' | 'pie' | 'radar' | 'scatter'
 export type SCHEME_COLORS = 'tx1' | 'tx2' | 'bg1' | 'bg2' | 'accent1' | 'accent2' | 'accent3' | 'accent4' | 'accent5' | 'accent6'
 
 export const LETTERS: Array<string> = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
@@ -110,6 +110,7 @@ export enum ChartType {
 	'bar' = 'bar',
 	'bar3d' = 'bar3D',
 	'bubble' = 'bubble',
+	'bubble3d' = 'bubble3D',
 	'doughnut' = 'doughnut',
 	'line' = 'line',
 	'pie' = 'pie',
@@ -693,6 +694,7 @@ export enum CHART_TYPE {
 	'BAR' = 'bar',
 	'BAR3D' = 'bar3D',
 	'BUBBLE' = 'bubble',
+	'BUBBLE3D' = 'bubble3D',
 	'DOUGHNUT' = 'doughnut',
 	'LINE' = 'line',
 	'PIE' = 'pie',

--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -139,7 +139,7 @@ export function createExcelWorksheet(chartObject: ISlideRelChart, zip: JSZip): P
 		{
 			// A: Start XML
 			let strSharedStrings = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
-			if (chartObject.opts._type === CHART_TYPE.BUBBLE) {
+			if (chartObject.opts._type === CHART_TYPE.BUBBLE || chartObject.opts._type === CHART_TYPE.BUBBLE3D) {
 				strSharedStrings +=
 					'<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="' + (intBubbleCols + 1) + '" uniqueCount="' + (intBubbleCols + 1) + '">'
 			} else if (chartObject.opts._type === CHART_TYPE.SCATTER) {
@@ -157,7 +157,7 @@ export function createExcelWorksheet(chartObject: ISlideRelChart, zip: JSZip): P
 			}
 
 			// C: Add `name`/Series
-			if (chartObject.opts._type === CHART_TYPE.BUBBLE) {
+			if (chartObject.opts._type === CHART_TYPE.BUBBLE || chartObject.opts._type === CHART_TYPE.BUBBLE3D) {
 				data.forEach((objData, idx) => {
 					if (idx === 0) strSharedStrings += '<si><t>X-Axis</t></si>'
 					else {
@@ -172,7 +172,7 @@ export function createExcelWorksheet(chartObject: ISlideRelChart, zip: JSZip): P
 			}
 
 			// D: Add `labels`/Categories
-			if (chartObject.opts._type !== CHART_TYPE.BUBBLE && chartObject.opts._type !== CHART_TYPE.SCATTER) {
+			if (chartObject.opts._type !== CHART_TYPE.BUBBLE && chartObject.opts._type !== CHART_TYPE.BUBBLE3D && chartObject.opts._type !== CHART_TYPE.SCATTER) {
 				data[0].labels.forEach(label => {
 					strSharedStrings += '<si><t>' + encodeXmlEntities(label) + '</t></si>'
 				})
@@ -185,7 +185,7 @@ export function createExcelWorksheet(chartObject: ISlideRelChart, zip: JSZip): P
 		// tables/table1.xml
 		{
 			let strTableXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
-			if (chartObject.opts._type === CHART_TYPE.BUBBLE) {
+			if (chartObject.opts._type === CHART_TYPE.BUBBLE || chartObject.opts._type === CHART_TYPE.BUBBLE3D) {
 				/*
 				strTableXml += '<table xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" id="1" name="Table1" displayName="Table1" ref="A1:'+ LETTERS[data.length-1] + (data[0].values.length+1) +'" totalsRowShown="0">';
 				strTableXml += '<tableColumns count="' + (data.length) +'">';
@@ -224,7 +224,7 @@ export function createExcelWorksheet(chartObject: ISlideRelChart, zip: JSZip): P
 			let strSheetXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
 			strSheetXml +=
 				'<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="x14ac" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac">'
-			if (chartObject.opts._type === CHART_TYPE.BUBBLE) {
+			if (chartObject.opts._type === CHART_TYPE.BUBBLE || chartObject.opts._type === CHART_TYPE.BUBBLE3D) {
 				strSheetXml += '<dimension ref="A1:' + LETTERS[intBubbleCols - 1] + (data[0].values.length + 1) + '" />'
 			} else if (chartObject.opts._type === CHART_TYPE.SCATTER) {
 				strSheetXml += '<dimension ref="A1:' + LETTERS[data.length - 1] + (data[0].values.length + 1) + '" />'
@@ -234,7 +234,7 @@ export function createExcelWorksheet(chartObject: ISlideRelChart, zip: JSZip): P
 
 			strSheetXml += '<sheetViews><sheetView tabSelected="1" workbookViewId="0"><selection activeCell="B1" sqref="B1" /></sheetView></sheetViews>'
 			strSheetXml += '<sheetFormatPr baseColWidth="10" defaultColWidth="11.5" defaultRowHeight="12" />'
-			if (chartObject.opts._type === CHART_TYPE.BUBBLE) {
+			if (chartObject.opts._type === CHART_TYPE.BUBBLE || chartObject.opts._type === CHART_TYPE.BUBBLE3D) {
 				strSheetXml += '<cols>'
 				strSheetXml += '<col min="1" max="' + data.length + '" width="11" customWidth="1" />'
 				strSheetXml += '</cols>'
@@ -1244,6 +1244,7 @@ function makeChartType(chartType: CHART_NAME, data: OptsChartData[], opts: IChar
 			break
 
 		case CHART_TYPE.BUBBLE:
+		case CHART_TYPE.BUBBLE3D:
 			/*
 				`data` = [
 					{ name:'X-Axis',     values:[1,2,3,4,5,6,7,8,9,10,11,12] },
@@ -1253,7 +1254,7 @@ function makeChartType(chartType: CHART_NAME, data: OptsChartData[], opts: IChar
 			*/
 
 			// 1: Start Chart
-			strXml += '<c:' + chartType + 'Chart>'
+			strXml += '<c:bubbleChart>'
 			strXml += '<c:varyColors val="0"/>'
 
 			// 2: Series: (One for each Y-Axis)
@@ -1357,7 +1358,7 @@ function makeChartType(chartType: CHART_NAME, data: OptsChartData[], opts: IChar
 				strXml += '      </c:numCache>'
 				strXml += '    </c:numRef>'
 				strXml += '  </c:bubbleSize>'
-				strXml += '  <c:bubble3D val="0"/>'
+				strXml += '  <c:bubble3D val="' + (chartType === CHART_TYPE.BUBBLE3D ? '1' : '0') + '"/>'
 
 				// F: Close "SERIES"
 				strXml += '</c:ser>'
@@ -1404,7 +1405,7 @@ function makeChartType(chartType: CHART_NAME, data: OptsChartData[], opts: IChar
 			strXml += '  <c:axId val="' + valAxisId + '"/>'
 
 			// 6: Close Chart tag
-			strXml += '</c:' + chartType + 'Chart>'
+			strXml += '</c:bubbleChart>'
 
 			// end switch
 			break
@@ -1571,7 +1572,7 @@ function makeCatAxis(opts: IChartOptsLib, axisId: string, valAxisId: string): st
 
 	// Build cat axis tag
 	// NOTE: Scatter and Bubble chart need two Val axises as they display numbers on x axis
-	if (opts._type === CHART_TYPE.SCATTER || opts._type === CHART_TYPE.BUBBLE) {
+	if (opts._type === CHART_TYPE.SCATTER || opts._type === CHART_TYPE.BUBBLE || opts._type === CHART_TYPE.BUBBLE3D) {
 		strXml += '<c:valAx>'
 	} else {
 		strXml += '<c:' + (opts.catLabelFormatCode ? 'dateAx' : 'catAx') + '>'
@@ -1596,7 +1597,7 @@ function makeCatAxis(opts: IChartOptsLib, axisId: string, valAxisId: string): st
 		})
 	}
 	// NOTE: Adding Val Axis Formatting if scatter or bubble charts
-	if (opts._type === CHART_TYPE.SCATTER || opts._type === CHART_TYPE.BUBBLE) {
+	if (opts._type === CHART_TYPE.SCATTER || opts._type === CHART_TYPE.BUBBLE || opts._type === CHART_TYPE.BUBBLE3D) {
 		strXml += '  <c:numFmt formatCode="' + (opts.valAxisLabelFormatCode ? encodeXmlEntities(opts.valAxisLabelFormatCode) : 'General') + '" sourceLinked="0"/>'
 	} else {
 		strXml += '  <c:numFmt formatCode="' + (encodeXmlEntities(opts.catLabelFormatCode) || 'General') + '" sourceLinked="0"/>'
@@ -1646,7 +1647,7 @@ function makeCatAxis(opts: IChartOptsLib, axisId: string, valAxisId: string): st
 
 	// Issue#149: PPT will auto-adjust these as needed after calcing the date bounds, so we only include them when specified by user
 	// Allow major and minor units to be set for double value axis charts
-	if (opts.catLabelFormatCode || opts._type === CHART_TYPE.SCATTER || opts._type === CHART_TYPE.BUBBLE) {
+	if (opts.catLabelFormatCode || opts._type === CHART_TYPE.SCATTER || opts._type === CHART_TYPE.BUBBLE || opts._type === CHART_TYPE.BUBBLE3D) {
 		if (opts.catLabelFormatCode) {
 			;['catAxisBaseTimeUnit', 'catAxisMajorTimeUnit', 'catAxisMinorTimeUnit'].forEach(opt => {
 				// Validate input as poorly chosen/garbage options will cause chart corruption and it wont render at all!
@@ -1665,7 +1666,7 @@ function makeCatAxis(opts: IChartOptsLib, axisId: string, valAxisId: string): st
 
 	// Close cat axis tag
 	// NOTE: Added closing tag of val or cat axis based on chart type
-	if (opts._type === CHART_TYPE.SCATTER || opts._type === CHART_TYPE.BUBBLE) {
+	if (opts._type === CHART_TYPE.SCATTER || opts._type === CHART_TYPE.BUBBLE || opts._type === CHART_TYPE.BUBBLE3D) {
 		strXml += '</c:valAx>'
 	} else {
 		strXml += '</c:' + (opts.catLabelFormatCode ? 'dateAx' : 'catAx') + '>'

--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -217,7 +217,7 @@ export function addChartDefinition(target: PresSlide, type: CHART_NAME | IChartM
 		if (options._type === CHART_TYPE.PIE) {
 			if (['bestFit', 'ctr', 'inEnd', 'outEnd'].indexOf(options.dataLabelPosition) < 0) delete options.dataLabelPosition
 		}
-		if (options._type === CHART_TYPE.BUBBLE || options._type === CHART_TYPE.LINE || options._type === CHART_TYPE.SCATTER) {
+		if (options._type === CHART_TYPE.BUBBLE || options._type === CHART_TYPE.BUBBLE3D || options._type === CHART_TYPE.LINE || options._type === CHART_TYPE.SCATTER) {
 			if (['b', 'ctr', 'l', 'r', 't'].indexOf(options.dataLabelPosition) < 0) delete options.dataLabelPosition
 		}
 		if (options._type === CHART_TYPE.BAR) {


### PR DESCRIPTION
Support bubble chart with a 3D appearance for bubbles instead of a solid display.

Implementation is done as a new chart type as Powerpoint UI defines it as a different type and bar 3D is defined as its own type as well. I'm not sure it is the best way, especially as even though Powerpoint UI treats it as a different chart type, in the XML it is a bubble chart with an option set to `1`. An alternative could be with a property (like `bubble3d: boolean` or `bubbleAppearence = 'solid' | '3d'`) but there is no existing type for bubble chart specific options.

If you prefer that setting to be done in any way feel free to tell and I will update the PR accordingly.