### PR TITLE
bugfix: escape object name in chart xml

### DIFF
--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -1412,7 +1412,7 @@ function makeChartType(chartType: CHART_NAME, data: IOptsChartData[], opts: ICha
 				strXml += '  <c:tx>'
 				strXml += '    <c:strRef>'
 				strXml += '      <c:f>Sheet1!$' + getExcelColName(idxColLtr + 1) + '$1</c:f>'
-				strXml += '      <c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>' + obj.name + '</c:v></c:pt></c:strCache>'
+				strXml += '      <c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>' + encodeXmlEntities(obj.name) + '</c:v></c:pt></c:strCache>'
 				strXml += '    </c:strRef>'
 				strXml += '  </c:tx>'
 


### PR DESCRIPTION
Object name is escaped at one place, but missing on another.