### PR TITLE
Add optional image shadow props

### DIFF
--- a/demos/browser/index.html
+++ b/demos/browser/index.html
@@ -743,6 +743,14 @@
 									<li>Source: URL variables</li>
 								</ul>
 							</div>
+							<div class="col">
+								<h6 class="text-primary">Slide 5: Image Shadows</h6>
+								<ul class="mb-0">
+									<li>Type: Outer</li>
+									<li>Type: None</li>
+									<li>Type: Inner</li>
+								</ul>
+							</div>
 						</div>
 					</div>
 					<div class="card-footer text-center">

--- a/demos/modules/demo_image.mjs
+++ b/demos/modules/demo_image.mjs
@@ -27,6 +27,7 @@ export function genSlides_Image(pptx) {
 	genSlide02(pptx);
 	genSlide03(pptx);
 	genSlide04(pptx);
+	genSlide05(pptx);
 }
 
 /**
@@ -278,4 +279,30 @@ function genSlide04(pptx) {
 		}
 	);
 	slide.addImage({ path: IMAGE_PATHS.sydneyBridge.path, x: 0.5, y: 5.16, h: 1.8, w: 12.33 });
+}
+
+/**
+ * SLIDE 5: Image Shadow
+ * @param {PptxGenJS} pptx
+ */
+ function genSlide05(pptx) {
+	let slide = pptx.addSlide({ sectionTitle: "Images" });
+
+	slide.addTable([[{ text: "Image Examples: Shadows", options: BASE_TEXT_OPTS_L }, BASE_TEXT_OPTS_R]], BASE_TABLE_OPTS);
+	slide.addNotes("API Docs: https://gitbrent.github.io/PptxGenJS/docs/api-images.html");
+	slide.slideNumber = { x: "50%", y: "95%", w: 1, h: 1, color: COLOR_BLUE };
+
+	// EXAMPLES
+
+	// OUTER SHADOW
+	slide.addText("Shadow: `type:outer`, `opacity:0.5`, `blur:20`, `color:000000`, `offset:20`, `angle:270`", { x: 0.5, y: 0.6, w: 6.0, h: 0.3, color: COLOR_BLUE });
+	slide.addImage({ path: IMAGE_PATHS.tokyoSubway.path, x: 0.78, y: 2.46, w: 3.3, h: 2, shadow: {type: 'outer', opacity: 0.5, blur: 20, color: '000000', offset: 20, angle: 270} });
+
+	// NO SHADOW
+	slide.addText("Shadow: `type:none`", { x: 5, y: 1.2, w: 6.0, h: 0.3, color: COLOR_BLUE });
+	slide.addImage({ path: IMAGE_PATHS.tokyoSubway.path, x: 4.52, y: 2.46, w: 3.3, h: 2, shadow: {type: 'none'} });
+
+	// INNER SHADOW
+	slide.addText("Shadow: `type:inner`, `opacity:1`, `blur:20`, `color:000000`, `offset:20`, `angle:270`", { x: 8, y: 0.6, w: 6.0, h: 0.3, color: COLOR_BLUE });
+	slide.addImage({ path: IMAGE_PATHS.tokyoSubway.path, x: 8.42, y: 2.46, w: 3.3, h: 2, shadow: {type: 'inner', opacity: 1, blur: 20, color: '000000', offset: 20, angle: 270} });
 }

--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -122,7 +122,7 @@ export interface HyperlinkProps {
 	 */
 	tooltip?: string
 }
-// used by: chart, text
+// used by: chart, text, image
 export interface ShadowProps {
 	/**
 	 * shadow type
@@ -525,6 +525,16 @@ export interface ImageProps extends PositionProps, DataOrPathProps, ObjectNamePr
 	 * @example 25 // 25% transparent
 	 */
 	transparency?: number
+	/**
+	 * Shadow Props
+	 * @example { type: 'outer',
+	 *            opacity: 0.5,
+	 *            blur: 20,
+	 *            color: '000000',
+	 *            offset: 20,
+	 *            angle: 270 }
+	 */
+	shadow?: ShadowProps
 }
 /**
  * Add media (audio/video) to slide

--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -45,8 +45,7 @@ import {
 	TextPropsOptions,
 } from './core-interfaces'
 import { getSlidesForTableRows } from './gen-tables'
-import { encodeXmlEntities, getNewRelId, getSmartParseNumber, inch2Emu, valToPts } from './gen-utils'
-import { correctShadowOptions } from './gen-xml'
+import { encodeXmlEntities, getNewRelId, getSmartParseNumber, inch2Emu, valToPts, correctShadowOptions } from './gen-utils'
 
 /** counter for included charts (used for index in their filenames) */
 let _chartCounter: number = 0
@@ -451,6 +450,7 @@ export function addImageDefinition(target: PresSlide, opt: ImageProps) {
 		flipH: opt.flipH || false,
 		transparency: opt.transparency || 0,
 		objectName: objectName,
+		shadow: correctShadowOptions(opt.shadow),
 	}
 
 	// STEP 4: Add this image to this Slide Rels (rId/rels count spans all slides! Count all images to get next rId)

--- a/src/gen-utils.ts
+++ b/src/gen-utils.ts
@@ -3,7 +3,7 @@
  */
 
 import { EMU, REGEX_HEX_COLOR, DEF_FONT_COLOR, ONEPT, SchemeColor, SCHEME_COLORS } from './core-enums'
-import { IChartOpts, PresLayout, TextGlowProps, PresSlide, ShapeFillProps, Color, ShapeLineProps, Coord } from './core-interfaces'
+import { IChartOpts, PresLayout, TextGlowProps, PresSlide, ShapeFillProps, Color, ShapeLineProps, Coord, ShadowProps } from './core-interfaces'
 
 /**
  * Translates any type of `x`/`y`/`w`/`h` prop to EMU
@@ -238,4 +238,56 @@ export function genXmlColorSelection(props: Color | ShapeFillProps | ShapeLinePr
  */
 export function getNewRelId(target: PresSlide): number {
 	return target._rels.length + target._relsChart.length + target._relsMedia.length + 1
+}
+
+/**
+ * Checks shadow options passed by user and performs corrections if needed.
+ * @param {ShadowProps} ShadowProps - shadow options
+ */
+export function correctShadowOptions(ShadowProps: ShadowProps): ShadowProps | undefined {
+	if (!ShadowProps || typeof ShadowProps !== 'object') {
+		//console.warn("`shadow` options must be an object. Ex: `{shadow: {type:'none'}}`")
+		return
+	}
+
+	// OPT: `type`
+	if (ShadowProps.type !== 'outer' && ShadowProps.type !== 'inner' && ShadowProps.type !== 'none') {
+		console.warn('Warning: shadow.type options are `outer`, `inner` or `none`.')
+		ShadowProps.type = 'outer'
+	}
+
+	// OPT: `angle`
+	if (ShadowProps.angle) {
+		// A: REALITY-CHECK
+		if (isNaN(Number(ShadowProps.angle)) || ShadowProps.angle < 0 || ShadowProps.angle > 359) {
+			console.warn('Warning: shadow.angle can only be 0-359')
+			ShadowProps.angle = 270
+		}
+
+		// B: ROBUST: Cast any type of valid arg to int: '12', 12.3, etc. -> 12
+		ShadowProps.angle = Math.round(Number(ShadowProps.angle))
+	}
+
+	// OPT: `opacity`
+	if (ShadowProps.opacity) {
+		// A: REALITY-CHECK
+		if (isNaN(Number(ShadowProps.opacity)) || ShadowProps.opacity < 0 || ShadowProps.opacity > 1) {
+			console.warn('Warning: shadow.opacity can only be 0-1')
+			ShadowProps.opacity = 0.75
+		}
+
+		// B: ROBUST: Cast any type of valid arg to int: '12', 12.3, etc. -> 12
+		ShadowProps.opacity = Number(ShadowProps.opacity)
+	}
+
+	// OPT: `color`
+	if (ShadowProps.color) {
+		// INCORRECT FORMAT
+		if (ShadowProps.color.startsWith('#')) {
+			console.warn('Warning: shadow.color should not include hash (#) character, , e.g. "FF0000"')
+			ShadowProps.color = ShadowProps.color.replace('#', '')
+		}
+	}
+
+	return ShadowProps
 }

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -24,7 +24,6 @@ import {
 	ISlideRelMedia,
 	ObjectOptions,
 	PresSlide,
-	ShadowProps,
 	SlideLayout,
 	TableCell,
 	TableCellProps,
@@ -622,6 +621,25 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 				strSlideXml += '  <a:ext cx="' + width + '" cy="' + height + '"/>'
 				strSlideXml += ' </a:xfrm>'
 				strSlideXml += ' <a:prstGeom prst="' + (rounding ? 'ellipse' : 'rect') + '"><a:avLst/></a:prstGeom>'
+
+				// Ref: @see http://officeopenxml.com/drwSp-effects.php
+				if (slideItemObj.options.shadow) {
+					slideItemObj.options.shadow.type = slideItemObj.options.shadow.type || 'outer'
+					slideItemObj.options.shadow.blur = valToPts(slideItemObj.options.shadow.blur || 8)
+					slideItemObj.options.shadow.offset = valToPts(slideItemObj.options.shadow.offset || 4)
+					slideItemObj.options.shadow.angle = Math.round((slideItemObj.options.shadow.angle || 270) * 60000)
+					slideItemObj.options.shadow.opacity = Math.round((slideItemObj.options.shadow.opacity || 0.75) * 100000)
+					slideItemObj.options.shadow.color = slideItemObj.options.shadow.color || DEF_TEXT_SHADOW.color
+
+					strSlideXml += '<a:effectLst>'
+					strSlideXml += '<a:' + slideItemObj.options.shadow.type + 'Shdw sx="100000" sy="100000" kx="0" ky="0" '
+					strSlideXml += ' algn="bl" rotWithShape="0" blurRad="' + slideItemObj.options.shadow.blur + '" '
+					strSlideXml += ' dist="' + slideItemObj.options.shadow.offset + '" dir="' + slideItemObj.options.shadow.angle + '">'
+					strSlideXml += '<a:srgbClr val="' + slideItemObj.options.shadow.color + '">'
+					strSlideXml += '<a:alpha val="' + slideItemObj.options.shadow.opacity + '"/></a:srgbClr>'
+					strSlideXml += '</a:outerShdw>'
+					strSlideXml += '</a:effectLst>'
+				}
 				strSlideXml += '</p:spPr>'
 				strSlideXml += '</p:pic>'
 				break
@@ -1925,45 +1943,4 @@ export function makeXmlTableStyles(): string {
  */
 export function makeXmlViewProps(): string {
 	return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>${CRLF}<p:viewPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:normalViewPr horzBarState="maximized"><p:restoredLeft sz="15611"/><p:restoredTop sz="94610"/></p:normalViewPr><p:slideViewPr><p:cSldViewPr snapToGrid="0" snapToObjects="1"><p:cViewPr varScale="1"><p:scale><a:sx n="136" d="100"/><a:sy n="136" d="100"/></p:scale><p:origin x="216" y="312"/></p:cViewPr><p:guideLst/></p:cSldViewPr></p:slideViewPr><p:notesTextViewPr><p:cViewPr><p:scale><a:sx n="1" d="1"/><a:sy n="1" d="1"/></p:scale><p:origin x="0" y="0"/></p:cViewPr></p:notesTextViewPr><p:gridSpacing cx="76200" cy="76200"/></p:viewPr>`
-}
-
-/**
- * Checks shadow options passed by user and performs corrections if needed.
- * @param {ShadowProps} ShadowProps - shadow options
- */
-export function correctShadowOptions(ShadowProps: ShadowProps) {
-	if (!ShadowProps || typeof ShadowProps !== 'object') {
-		//console.warn("`shadow` options must be an object. Ex: `{shadow: {type:'none'}}`")
-		return
-	}
-
-	// OPT: `type`
-	if (ShadowProps.type !== 'outer' && ShadowProps.type !== 'inner' && ShadowProps.type !== 'none') {
-		console.warn('Warning: shadow.type options are `outer`, `inner` or `none`.')
-		ShadowProps.type = 'outer'
-	}
-
-	// OPT: `angle`
-	if (ShadowProps.angle) {
-		// A: REALITY-CHECK
-		if (isNaN(Number(ShadowProps.angle)) || ShadowProps.angle < 0 || ShadowProps.angle > 359) {
-			console.warn('Warning: shadow.angle can only be 0-359')
-			ShadowProps.angle = 270
-		}
-
-		// B: ROBUST: Cast any type of valid arg to int: '12', 12.3, etc. -> 12
-		ShadowProps.angle = Math.round(Number(ShadowProps.angle))
-	}
-
-	// OPT: `opacity`
-	if (ShadowProps.opacity) {
-		// A: REALITY-CHECK
-		if (isNaN(Number(ShadowProps.opacity)) || ShadowProps.opacity < 0 || ShadowProps.opacity > 1) {
-			console.warn('Warning: shadow.opacity can only be 0-1')
-			ShadowProps.opacity = 0.75
-		}
-
-		// B: ROBUST: Cast any type of valid arg to int: '12', 12.3, etc. -> 12
-		ShadowProps.opacity = Number(ShadowProps.opacity)
-	}
 }

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -521,7 +521,7 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 				}
 
 				// EFFECTS > SHADOW: REF: @see http://officeopenxml.com/drwSp-effects.php
-				if (slideItemObj.options.shadow) {
+				if (slideItemObj.options.shadow && slideItemObj.options.shadow.type !== 'none') {
 					slideItemObj.options.shadow.type = slideItemObj.options.shadow.type || 'outer'
 					slideItemObj.options.shadow.blur = valToPts(slideItemObj.options.shadow.blur || 8)
 					slideItemObj.options.shadow.offset = valToPts(slideItemObj.options.shadow.offset || 4)
@@ -530,12 +530,13 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 					slideItemObj.options.shadow.color = slideItemObj.options.shadow.color || DEF_TEXT_SHADOW.color
 
 					strSlideXml += '<a:effectLst>'
-					strSlideXml += '<a:' + slideItemObj.options.shadow.type + 'Shdw sx="100000" sy="100000" kx="0" ky="0" '
-					strSlideXml += ' algn="bl" rotWithShape="0" blurRad="' + slideItemObj.options.shadow.blur + '" '
+					strSlideXml += '<a:' + slideItemObj.options.shadow.type + 'Shdw'
+					strSlideXml += slideItemObj.options.shadow.type === 'outer' ? ' sx="100000" sy="100000" kx="0" ky="0" algn="bl" rotWithShape="0"' : ''
+					strSlideXml += ' blurRad="' + slideItemObj.options.shadow.blur + '"'
 					strSlideXml += ' dist="' + slideItemObj.options.shadow.offset + '" dir="' + slideItemObj.options.shadow.angle + '">'
 					strSlideXml += '<a:srgbClr val="' + slideItemObj.options.shadow.color + '">'
 					strSlideXml += '<a:alpha val="' + slideItemObj.options.shadow.opacity + '"/></a:srgbClr>'
-					strSlideXml += '</a:outerShdw>'
+					strSlideXml += '</a:' + slideItemObj.options.shadow.type + 'Shdw>'
 					strSlideXml += '</a:effectLst>'
 				}
 
@@ -622,8 +623,8 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 				strSlideXml += ' </a:xfrm>'
 				strSlideXml += ' <a:prstGeom prst="' + (rounding ? 'ellipse' : 'rect') + '"><a:avLst/></a:prstGeom>'
 
-				// Ref: @see http://officeopenxml.com/drwSp-effects.php
-				if (slideItemObj.options.shadow) {
+				// EFFECTS > SHADOW: REF: @see http://officeopenxml.com/drwSp-effects.php
+				if (slideItemObj.options.shadow && slideItemObj.options.shadow.type !== 'none') {
 					slideItemObj.options.shadow.type = slideItemObj.options.shadow.type || 'outer'
 					slideItemObj.options.shadow.blur = valToPts(slideItemObj.options.shadow.blur || 8)
 					slideItemObj.options.shadow.offset = valToPts(slideItemObj.options.shadow.offset || 4)
@@ -632,12 +633,13 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 					slideItemObj.options.shadow.color = slideItemObj.options.shadow.color || DEF_TEXT_SHADOW.color
 
 					strSlideXml += '<a:effectLst>'
-					strSlideXml += '<a:' + slideItemObj.options.shadow.type + 'Shdw sx="100000" sy="100000" kx="0" ky="0" '
-					strSlideXml += ' algn="bl" rotWithShape="0" blurRad="' + slideItemObj.options.shadow.blur + '" '
+					strSlideXml += '<a:' + slideItemObj.options.shadow.type + 'Shdw'
+					strSlideXml += slideItemObj.options.shadow.type === 'outer' ? ' sx="100000" sy="100000" kx="0" ky="0" algn="bl" rotWithShape="0"' : ''
+					strSlideXml += ' blurRad="' + slideItemObj.options.shadow.blur + '"'
 					strSlideXml += ' dist="' + slideItemObj.options.shadow.offset + '" dir="' + slideItemObj.options.shadow.angle + '">'
 					strSlideXml += '<a:srgbClr val="' + slideItemObj.options.shadow.color + '">'
 					strSlideXml += '<a:alpha val="' + slideItemObj.options.shadow.opacity + '"/></a:srgbClr>'
-					strSlideXml += '</a:outerShdw>'
+					strSlideXml += '</a:' + slideItemObj.options.shadow.type + 'Shdw>'
 					strSlideXml += '</a:effectLst>'
 				}
 				strSlideXml += '</p:spPr>'


### PR DESCRIPTION
**Description**
This PR takes the shape shadow implementation and adapts it to images.
Related to [Issue #986](https://github.com/gitbrent/PptxGenJS/issues/986)

**Example**
```js
let pptx = new PptxGenJS();
let slide = pptx.addSlide();

slide.addImage({
  x: 1,
  y: 1,
  path: "https://images.unsplash.com/photo-1506744038136-46273834b3fb?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwyMTIyMnwwfDF8c2VhcmNofDJ8fGxhbmRzY2FwZXxlbnwwfHx8fDE2NTg5MzE0MDM&ixlib=rb-1.2.1&q=80&w=1080",
  shadow: {
    type: "outer",
    angle: 90,
    blur: 10,
    color: "000000",
    offset: 4,
    opacity: 0.5
  }
});

pptx.writeFile({ fileName: "PptxGenJS-Sandbox.pptx" });

```
Sample PPT files:
[PptxGenJS-Shadows.pptx](https://github.com/gitbrent/PptxGenJS/files/9308201/PptxGenJS-Shadows.pptx)
[PptxGenJS_Demo_Image_20220811112738439.pptx](https://github.com/gitbrent/PptxGenJS/files/9308203/PptxGenJS_Demo_Image_20220811112738439.pptx)

