### PR TITLE
fix(table): Added placeholder properties to tables 

### DIFF
--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -893,6 +893,8 @@ export interface TableProps extends PositionProps, TextBaseProps, ObjectNameProp
 	 * @deprecated v3.3.0 - use `autoPageSlideStartY`
 	 */
 	newSlideStartY?: number
+
+	placeholder?: string
 }
 export interface TableCell {
 	_type: SLIDE_OBJECT_TYPES.tablecell

--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -731,6 +731,15 @@ export function addTableDefinition(
 	let opt: TableProps = options && typeof options === 'object' ? options : {}
 	opt.objectName = opt.objectName ? encodeXmlEntities(opt.objectName) : `Table ${target._slideObjects.filter(obj => obj._type === SLIDE_OBJECT_TYPES.table).length}`
 
+	if (opt.placeholder && target._slideLayout && target._slideLayout._slideObjects) {
+		// Placeholder
+		let placeHold = target._slideLayout._slideObjects.filter(
+			item => item._type == 'placeholder' && item.options && item.options.placeholder && item.options.placeholder == opt.placeholder
+		)[0]
+
+		if (placeHold && placeHold.options) opt = { ...opt, ...placeHold.options}
+	}
+	
 	// STEP 1: REALITY-CHECK
 	{
 		// A: check for empty

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1715,6 +1715,8 @@ declare namespace PptxGenJS {
 		 * @deprecated v3.3.0 - use `autoPageSlideStartY`
 		 */
 		newSlideStartY?: number
+
+		placeholder?: string
 	}
 	export interface TableCell {
 		text?: string | TableCell[]


### PR DESCRIPTION
# Description
Adds the placeholder property to TableProps to allow it to inherit from a given placeholder

# Example
```js
let rows: pptxgen.TableRow[] = [
        [
          {text: "data1", options: null}, 
          {text: "data2", options: {border: [null, null, {color:'DA70D6'}, null]}},
        ],
        [
          {text: "data3", options: null}, 
          {text: "data4", options: {border: [null, null, {color:'DA70D6'}, null]}},
        ],
        [
          {text: "data5", options: null}, 
          {text: "data6", options: {border: [null, null, {color:'DA70D6'}, null]}},
        ],
      ];
    
    slide.addTable(rows, { placeholder: "table_placeholder", align: "left", fontFace: "Arial" });
```