### PR TITLE
Update text docs: transparency + wrap

### DIFF
--- a/docs/api-text.md
+++ b/docs/api-text.md
@@ -66,9 +66,11 @@ slide.addText([{ text: "TEXT", options: { OPTIONS } }]);
 | `strike`              | string             |         |         | text strikethrough        | `dblStrike` or `sngStrike`                                                                                                     |
 | `subscript`           | boolean            |         | `false` | subscript text            | `true` or `false`                                                                                                              |
 | `superscript`         | boolean            |         | `false` | superscript text          | `true` or `false`                                                                                                              |
+| `transparency`        | number             |         | `0`     | transparency              | Percentage: 0-100                                                                                                              |
 | `underline`           | TextUnderlineProps |         |         | underline color/style     | [TextUnderlineProps](/PptxGenJS/docs/types#text-underline-props-textunderlineprops)                                            |
 | `valign`              | string             |         |         | vertical alignment        | `top` or `middle` or `bottom`                                                                                                  |
 | `vert`                | string             |         | `horz`  | text direction            | `eaVert` or `horz` or `mongolianVert` or `vert` or `vert270` or `wordArtVert` or `wordArtVertRtl`                              |
+| `wrap`                | boolean            |         | `true`  | text wrapping             | `true` or `false`                                                                                                              |
 
 ### Shadow Properties (`ShadowProps`)
 


### PR DESCRIPTION
Add missing properties to text API docs:
- `transparency`
- `wrap`

These are already supported by the lib, but were still missing from the documentation.