### PR TITLE
fix: prevent empty txBody in autopaged empty cells

### DIFF
--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -1322,6 +1322,11 @@ export function genXmlTextBody (slideObj: ISlideObject | TableCell): string {
 		// D: End paragraph
 		strSlideXml += '</a:p>'
 	})
+	
+	// PowerPoint shows repair message if txBody misses p #1048
+	if (!arrLines.length) {
+		strSlideXml += '<a:p><a:endParaRPr /></a:p>'
+	}
 
 	// STEP 7: Close the textBody
 	strSlideXml += slideObj._type === SLIDE_OBJECT_TYPES.tablecell ? '</a:txBody>' : '</p:txBody>'


### PR DESCRIPTION
Whenever autopage generates a new slides, there might be empty cells, that need to be properly generated to avoid the 'repair' message in PowerPoint (here's the issue: https://github.com/gitbrent/PptxGenJS/issues/1048).

Here is the content generated before this fix for empty cells in rows broken into 2 or more pages
```xml
<a:tc>
  <a:txBody>
      <a:bodyPr/>
      <a:lstStyle/>
                              <----- missing empty p
  </a:txBody>
  ...
</a:tc>
```

This triggers the 'repair' message in PowerPoint.

Here is what PowerPoint generates after repairing the file:

```xml
<a:tc>
  <a:txBody>
    <a:bodyPr/>
    <a:lstStyle/>
    <a:p>
      <a:endParaRPr/>
    </a:p>
  </a:txBody>
  ...
</a:tc>
```