### PR TITLE
bugfix: radar chart line does not respect chartColors

### DIFF
--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -727,6 +727,12 @@ function makeChartType(chartType: CHART_NAME, data: OptsChartData[], opts: IChar
 						'" cap="flat"><a:solidFill>' +
 						createColorElement(opts.dataBorder.color) +
 						'</a:solidFill><a:prstDash val="solid"/><a:round/></a:ln>'
+				} else {
+					strXml += '<a:ln w="' + valToPts(opts.lineSize) + '" cap="' + createLineCap(opts.lineCap) + '">'
+					strXml += '  <a:solidFill>' + createColorElement(seriesColor) + '</a:solidFill>'
+					strXml += '  <a:prstDash val="' + (opts.lineDash || 'solid') + '"/>'
+					strXml += '  <a:round/>'
+					strXml += '</a:ln>'
 				}
 
 				strXml += createShadowElement(opts.shadow, DEF_SHAPE_SHADOW)
@@ -1297,8 +1303,11 @@ function makeChartType(chartType: CHART_NAME, data: OptsChartData[], opts: IChar
 							createColorElement(opts.dataBorder.color) +
 							'</a:solidFill><a:prstDash val="solid"/><a:round/></a:ln>'
 					} else {
-						strXml += '<a:ln w="' + valToPts(opts.lineSize) + '" cap="flat"><a:solidFill>' + createColorElement(tmpSerColor) + '</a:solidFill>'
-						strXml += '<a:prstDash val="' + (opts.lineDash || 'solid') + '"/><a:round/></a:ln>'
+						strXml += '<a:ln w="' + valToPts(opts.lineSize) + '" cap="flat">'
+						strXml += '  <a:solidFill>' + createColorElement(tmpSerColor) + '</a:solidFill>'
+						strXml += '  <a:prstDash val="' + (opts.lineDash || 'solid') + '"/>'
+						strXml += '  <a:round/>'
+						strXml += '</a:ln>'
 					}
 
 					// Shadow


### PR DESCRIPTION
Option `chartColors` sets the color of markers on a radar chart but is ignored for lines which take Powerpoint's default colors. A [comment in examples](https://github.com/gitbrent/PptxGenJS/blob/a18a36a1a597e1130417741ea4d8d9363f7f5b48/demos/modules/demo_chart.mjs#L1595) states that it should be used for markers too:

> chartColors: COLORS_RYGU, // marker & line color

In case there is no dataBorder specify, fallback to chartColors.

This is very similar to bubble chart fallback (which is reindented to be be more explicit in the XML elements it creates) except that cap can be parameterized in radar.