### PR TITLE
bugfix: handle holeSize=0 for doughnut chart

### DIFF
--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -1613,7 +1613,7 @@ function makeChartType (chartType: CHART_NAME, data: IOptsChartData[], opts: ICh
 			// 4: Close "SERIES"
 			strXml += '  </c:ser>'
 			strXml += `  <c:firstSliceAng val="${opts.firstSliceAng ? Math.round(opts.firstSliceAng) : 0}"/>`
-			if (chartType === CHART_TYPE.DOUGHNUT) strXml += `<c:holeSize val="${opts.holeSize || 50}"/>`
+			if (chartType === CHART_TYPE.DOUGHNUT) strXml += `<c:holeSize val="${typeof opts.holeSize === 'number' ? opts.holeSize : 50)}"/>`
 			strXml += '</c:' + chartType + 'Chart>'
 
 			// Done with Doughnut/Pie


### PR DESCRIPTION
Doughnut chart ignores holeSize=0 as a falsy value and takes is default of 50.

Code now checks the type of holeSize to treat 0 as a number and display doughnuts with no hole at all.

This leads to a chart very similar to a pie chart, but means that we do not have to change chart type for the 0 special case.