### PR TITLE
added bullet.color option

### DIFF
--- a/demos/modules/demo_text.mjs
+++ b/demos/modules/demo_text.mjs
@@ -316,7 +316,7 @@ function genSlide03(pptx) {
 			{ text: "`bullet: { code: '25BA' }`", options: { fontSize: 18, color: pptx.colors.ACCENT1, bullet: { code: "25BA" } } },
 			{ text: "`bullet: { code: '25D1' }`", options: { fontSize: 18, color: pptx.colors.ACCENT5, bullet: { code: "25D1" } } },
 			{ text: "`bullet: { code: '25CC' }`", options: { fontSize: 18, color: pptx.colors.ACCENT6, bullet: { code: "25CC" } } },
-			{ text: "Mix and... ", options: { fontSize: 24, color: "FF0000", bullet: { code: "25BA" } } },
+			{ text: "Mix and... ", options: { fontSize: 24, color: "FF0000", bullet: { code: "25BA", color: "0000FF" } } },
 			{ text: "match formatting as well.", options: { fontSize: 16, color: "00CD00" } },
 		],
 		{ x: 7.0, y: 5.5, w: 5.75, h: 1.5, fontFace: "Arial", fill: pptx.colors.BACKGROUND2 }

--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -284,6 +284,12 @@ export interface TextBaseProps {
 		 */
 		characterCode?: string
 		/**
+		 * Bullet color (hex format)
+		 * @example 'FF0000' // red
+		 */
+		color?: string
+
+		/**
 		 * Indentation (space between bullet and text) (points)
 		 * @since v3.3.0
 		 * @default 27 // DEF_BULLET_MARGIN

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -828,6 +828,7 @@ function slideObjectRelationsToXml (slide: PresSlide | SlideLayout, defaultRels:
  * @return {string} XML
  */
 function genXmlParagraphProperties (textObj: ISlideObject | TextProps, isDefault: boolean): string {
+	let strXmlBulletColor = ''
 	let strXmlBullet = ''
 	let strXmlLnSpc = ''
 	let strXmlParaSpc = ''
@@ -922,6 +923,14 @@ function genXmlParagraphProperties (textObj: ISlideObject | TextProps, isDefault
 				}" indent="-${bulletMarL}"`
 				strXmlBullet = `<a:buSzPct val="100000"/><a:buChar char="${BULLET_TYPES.DEFAULT}"/>`
 			}
+			if(textObj.options.bullet.color) {
+				// check if color is hex
+				if (!/^([0-9A-Fa-f]{3}){1,2}$/.test(textObj.options.bullet.color)) {
+					console.warn('Warning: `bullet.color should be a hex code (ex: FF0000)`!');
+					textObj.options.bullet.color = '000000';
+				}
+				strXmlBulletColor = `<a:buClr><a:srgbClr val="${textObj.options.bullet.color}" /></a:buClr>`
+			}
 		} else if (textObj.options.bullet) {
 			paragraphPropXml += ` marL="${textObj.options.indentLevel && textObj.options.indentLevel > 0 ? bulletMarL + bulletMarL * textObj.options.indentLevel : bulletMarL
 			}" indent="-${bulletMarL}"`
@@ -940,7 +949,7 @@ function genXmlParagraphProperties (textObj: ISlideObject | TextProps, isDefault
 
 		// B: Close Paragraph-Properties
 		// IMPORTANT: strXmlLnSpc, strXmlParaSpc, and strXmlBullet require strict ordering - anything out of order is ignored. (PPT-Online, PPT for Mac)
-		paragraphPropXml += '>' + strXmlLnSpc + strXmlParaSpc + strXmlBullet + strXmlTabStops
+		paragraphPropXml += '>' + strXmlLnSpc + strXmlParaSpc + strXmlBulletColor + strXmlBullet + strXmlTabStops
 		if (isDefault) paragraphPropXml += genXmlTextRunProperties(textObj.options, true)
 		paragraphPropXml += '</' + tag + '>'
 	}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1113,6 +1113,11 @@ declare namespace PptxGenJS {
 			 */
 			characterCode?: string
 			/**
+			 * Bullet color (hex format)
+			 * @example 'FF0000' // red
+			 */
+			color?: string
+			/**
 			 * Indentation (space between bullet and text) (points)
 			 * @since v3.3.0
 			 * @default 27 // DEF_BULLET_MARGIN


### PR DESCRIPTION
This pr adds the option to supply a color to the bullet object, so you can add color to the bullets without coloring the text.

I'd like to update the documentation as well, but I'm not sure how to do it, if someone can point me in the right direction I'd be happy to add that in.

e.g.

```JavaScript
slide.addText(
  [
    {
      text: "Bullet 1",
      options: {
        bullet: { code: "25BA", color: "0000FF" },
      },
    },
    {
      text: "Bullet 2",
      options: {
        bullet: { code: "25BA", color: "FF0000" },
      },
    },

    {
      text: "Bullet 3",
      options: {
        bullet: { code: "25BA", color: "00FF00" },
      },
    },
  ]
)
```