### PR TITLE
Fix placeholder text formatting issues

### DIFF
--- a/demos/modules/masters.mjs
+++ b/demos/modules/masters.mjs
@@ -124,6 +124,49 @@ export function createMasterSlides(pptx) {
 		],
 	});
 
+	// MASTER_WITH_BULLETS
+	pptx.defineSlideMaster({
+		title: "MASTER_WITH_BULLETS",
+		background: { color: "E1E1E1", transparency: 50 },
+		margin: [0.5, 0.25, 1.0, 0.25],
+		slideNumber: { x: 0.6, y: 7.1, color: "FFFFFF", fontFace: "Arial", fontSize: 10, bold: true },
+		objects: [
+			{
+				rect: { x: 0.0, y: 6.9, w: "100%", h: 0.6, fill: { color: "003b75" } },
+			},
+			{
+				text: {
+					options: { x: 0, y: 6.9, w: "100%", h: 0.6, align: "center", valign: "middle", color: "FFFFFF", fontSize: 12 },
+					text: "S.T.A.R. Laboratories - Confidential",
+				},
+			},
+			{
+				placeholder: {
+					options: {
+						name: "header",
+						type: "title",
+						x: 0.6,
+						y: 0.2,
+						w: 12,
+						h: 1.0,
+						margin: 0,
+						align: "center",
+						valign: "middle",
+						color: "404040",
+						//fontSize: 18,
+					},
+					text: "", // USAGE: Leave blank to have powerpoint substitute default placeholder text (ex: "Click to add title")
+				},
+			},
+			{
+				placeholder: {
+					options: { name: "bullets", type: "body", x: 0.6, y: 1.5, w: 12, h: 5.25, fontSize: 14, fontFace: "arial", bullet: { type: "bullet", characterCode: "25CF" } },
+					text: "Bullet 1\nBullet 2\nBullet 3\nBullet 4\nBullet 5",
+				},
+			},
+		],
+	});
+
 	// THANKS_SLIDE (THANKS_PLACEHOLDER)
 	pptx.defineSlideMaster({
 		title: "THANKS_SLIDE",

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -1071,7 +1071,7 @@ function genXmlTextRun (textObj: TextProps): string {
 function genXmlBodyProperties (slideObject: ISlideObject | TableCell): string {
 	let bodyProperties = '<a:bodyPr'
 
-	if (slideObject && slideObject._type === SLIDE_OBJECT_TYPES.text && slideObject.options._bodyProp) {
+	if (slideObject && (slideObject._type === SLIDE_OBJECT_TYPES.text || slideObject._type === SLIDE_OBJECT_TYPES.placeholder) && slideObject.options._bodyProp) {
 		// PPT-2019 EX: <a:bodyPr wrap="square" lIns="1270" tIns="1270" rIns="1270" bIns="1270" rtlCol="0" anchor="ctr"/>
 
 		// A: Enable or disable textwrapping none or square

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -885,13 +885,11 @@ function genXmlParagraphProperties (textObj: ISlideObject | TextProps, isDefault
 		if (typeof textObj.options.bullet === 'object') {
 			if (textObj?.options?.bullet?.indent) bulletMarL = valToPts(textObj.options.bullet.indent)
 
-			if (textObj.options.bullet.type) {
-				if (textObj.options.bullet.type.toString().toLowerCase() === 'number') {
-					paragraphPropXml += ` marL="${textObj.options.indentLevel && textObj.options.indentLevel > 0 ? bulletMarL + bulletMarL * textObj.options.indentLevel : bulletMarL
-					}" indent="-${bulletMarL}"`
-					strXmlBullet = `<a:buSzPct val="100000"/><a:buFont typeface="+mj-lt"/><a:buAutoNum type="${textObj.options.bullet.style || 'arabicPeriod'}" startAt="${textObj.options.bullet.numberStartAt || textObj.options.bullet.startAt || '1'
-					}"/>`
-				}
+			if (textObj.options.bullet.type && textObj.options.bullet.type.toString().toLowerCase() === 'number') {
+				paragraphPropXml += ` marL="${textObj.options.indentLevel && textObj.options.indentLevel > 0 ? bulletMarL + bulletMarL * textObj.options.indentLevel : bulletMarL
+				}" indent="-${bulletMarL}"`
+				strXmlBullet = `<a:buSzPct val="100000"/><a:buFont typeface="+mj-lt"/><a:buAutoNum type="${textObj.options.bullet.style || 'arabicPeriod'}" startAt="${textObj.options.bullet.numberStartAt || textObj.options.bullet.startAt || '1'
+				}"/>`
 			} else if (textObj.options.bullet.characterCode) {
 				let bulletCode = `&#x${textObj.options.bullet.characterCode};`
 


### PR DESCRIPTION
This PR fixes several bugs related to placeholders on master slides that can be observed in [this minimal demo repo](https://github.com/mikemeerschaert/pptxgen-placeholder-text-issues-demo)

### Valign and Margin in master slides
When creating a placeholder on a master slide, the **valign** and **margin** options are disregarded on the layout slide (in ppt, go to **View > Slide Master** and examine the items added to the layout slide, even if you specify valign and/or margin, the items on the layout slide will still have the default values.

This issue is somewhat related to #640. The fix for that issue fixed the generated slides that use the master and placeholders from within the library, but unfortunately, it didn't fix the issue on the master slides themselves.

This causes issues when you generate a pptx and then you want to add more slides to that file manually in PowerPoint using the generated master slides.

### Bullets in master slides
This one is very specific and probably doesn't come up much, but it came up for me, and since I was already in the library fixing the above issue, I decided to also developed a fix for this one. 

When you supply `type: "bullet"` and a custom `characterCode` to bulleted text in a placeholder, the placeholder still uses the default bullet code `2022`. The easy workaround is to just not supply a type and it will default to bullet, but it is very confusing when you run into it.

e.g. 

```JavaScript
presentation.defineSlideMaster({
  title: "Bullet point demo",
  background: { color: "FFFFFF" },
  objects: [
    {
      placeholder: {
        options: {
          name: "Bullets",
          type: "body",
          bullet: {
            type: "bullet",
            characterCode: "25CF",
          },
          x: 0.5,
          y: 0.1,
          w: 9,
          h: 1,
          fontSize: 12,
          fontFace: "Arial",
        },
        text: "bullet 1\nbullet 2\nbullet 3",
      },
    },
  ],
})
```