### PR TITLE
Bump jszip to ^3.10.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "dist/pptxgen.js"
   ],
   "dependencies": {
-    "jszip": "^3.7.1"
+    "jszip": "^3.10.1"
   },
   "authors": [
     "Brent Ely <https://github.com/gitbrent>"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "pptxgenjs",
-  "version": "3.12.0-beta",
+  "version": "3.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pptxgenjs",
-      "version": "3.12.0-beta",
+      "version": "3.12.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.7.3",
         "https": "^1.0.0",
         "image-size": "^1.0.0",
-        "jszip": "^3.7.1"
+        "jszip": "^3.10.1"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^21.0.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/node": "^18.7.3",
     "https": "^1.0.0",
     "image-size": "^1.0.0",
-    "jszip": "^3.7.1"
+    "jszip": "^3.10.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^21.0.2",


### PR DESCRIPTION
I'm not 100% sure how to test this or if other files need to be updated, but getting this PR out there.


JSZip changelog:
### v3.10.1 2022-08-02

- Add sponsorship files.
    + If you appreciate the time spent maintaining JSZip then I would really appreciate [your sponsorship](https://github.com/sponsors/Stuk).
- Consolidate metadata types and expose OnUpdateCallback [#851](https://github.com/Stuk/jszip/pull/851) and [#852](https://github.com/Stuk/jszip/pull/852)
- use `const` instead `var` in example from README.markdown [#828](https://github.com/Stuk/jszip/pull/828)
- Switch manual download link to HTTPS [#839](https://github.com/Stuk/jszip/pull/839)

Internals:

- Replace jshint with eslint [#842](https://github.com/Stuk/jszip/pull/842)
- Add performance tests [#834](https://github.com/Stuk/jszip/pull/834)

### v3.10.0 2022-05-20

- Change setimmediate dependency to more efficient one. Fixes https://github.com/Stuk/jszip/issues/617 (see [#829](https://github.com/Stuk/jszip/pull/829))
- Update types of `currentFile` metadata to include `null` (see [#826](https://github.com/Stuk/jszip/pull/826))

### v3.9.1 2022-04-06

- Fix recursive definition of `InputFileFormat` introduced in 3.9.0.

### v3.9.0 2022-04-04

- Update types JSZip#loadAsync to accept a promise for data, and remove arguments from `new JSZip()` (see [#752](https://github.com/Stuk/jszip/pull/752))
- Update types for `compressionOptions` to JSZipFileOptions and JSZipGeneratorOptions (see [#722](https://github.com/Stuk/jszip/pull/722))
- Add types for `generateInternalStream` (see [#774](https://github.com/Stuk/jszip/pull/774))

### v3.8.0 2022-03-30

- Santize filenames when files are loaded with `loadAsync`, to avoid ["zip slip" attacks](https://snyk.io/research/zip-slip-vulnerability). The original filename is available on each zip entry as `unsafeOriginalName`. See the [documentation](https://stuk.github.io/jszip/documentation/api_jszip/load_async.html). Many thanks to McCaulay Hudson for reporting.


--

Closes #1254
