### PR TITLE
Fix category display in Google Slides

### DIFF
--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -955,6 +955,14 @@ function makeChartType (chartType: CHART_NAME, data: IOptsChartData[], opts: ICh
 						obj.labels[0].forEach((label, idx) => (strXml += `<c:pt idx="${idx}"><c:v>${encodeXmlEntities(label)}</c:v></c:pt>`))
 						strXml += '    </c:numCache>'
 						strXml += '  </c:numRef>'
+					} else if (obj.labels.length === 1) {
+						strXml += '  <c:strRef>'
+						strXml += `    <c:f>Sheet1!$A$2:$${getExcelColName(obj.labels.length)}$${obj.labels[0].length + 1}</c:f>`
+						strXml += '    <c:strCache>'
+						strXml += `      <c:ptCount val="${obj.labels[0].length}"/>`
+						obj.labels[0].forEach((label, idx) => (strXml += `<c:pt idx="${idx}"><c:v>${encodeXmlEntities(label)}</c:v></c:pt>`))
+						strXml += '    </c:strCache>'
+						strXml += '  </c:strRef>'
 					} else {
 						strXml += '  <c:multiLvlStrRef>'
 						strXml += `    <c:f>Sheet1!$A$2:$${getExcelColName(obj.labels.length)}$${obj.labels[0].length + 1}</c:f>`


### PR DESCRIPTION
This fixes an issue when importing generated PPTX files with charts into Google Slides.

It appears Google Slides' importer does not like the use of `multiLvlStrRef`, and displays categories as simple numbers.

---

For example, using this code to generate a pptx file:
```javascript
  const pres = new pptxgen();
  const slide = pres.addSlide();
  slide.addChart(
    pres.ChartType.bar,
    [
      {
        name: "Categories",
        labels: ["Category A", "Category B", "Category C"],
        values: [500, 200, 350],
      },
    ],
    {
      x: 1,
      y: 1,
      w: 5,
      h: 3,
    }
  );
```

Appears like this in PowerPoint vs Google Slides:

<table>
<tr>
 <td>Microsoft PowerPoint</td>
 <td>Google Slides</td>
<tr>
 <td>
<img width="771" alt="CleanShot 2023-07-10 at 16 20 53@2x" src="https://github.com/gitbrent/PptxGenJS/assets/25229479/6bbef62c-698f-424a-a53b-694341f04b81">
</td>
 <td>
<img width="883" alt="CleanShot 2023-07-10 at 16 22 33@2x" src="https://github.com/gitbrent/PptxGenJS/assets/25229479/d5611b1e-7c33-45a3-9b8a-c2b05ded097a">
</td>
</table>

---

Using `strRef` instead of `multiLvlStrRef` when there is only one set of labels appears to fix this issue.

- [Example pptx before this change](https://github.com/gitbrent/PptxGenJS/files/11998504/output-bad.pptx)
- [Example pptx after this change](https://github.com/gitbrent/PptxGenJS/files/11998507/output-good.pptx)