### PR TITLE
feat: add firstSlideNum prop of PresentationProps

### DIFF
--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -1864,6 +1864,7 @@ export interface PresentationProps {
 	subject: string
 	theme: ThemeProps
 	title: string
+	firstSlideNum: number
 }
 // PRIVATE interface
 export interface IPresentationProps extends PresentationProps {

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -1769,7 +1769,7 @@ export function makeXmlPresentation (pres: IPresentationProps): string {
 	let strXml =
 		`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>${CRLF}` +
 		'<p:presentation xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" ' +
-		`xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" ${pres.rtlMode ? 'rtl="1"' : ''} saveSubsetFonts="1" autoCompressPictures="0">`
+		`xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" firstSlideNum="${pres.firstSlideNum}" ${pres.rtlMode ? 'rtl="1"' : ''} saveSubsetFonts="1" autoCompressPictures="0">`
 
 	// STEP 1: Add slide master (SPEC: tag 1 under <presentation>)
 	strXml += '<p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rId1"/></p:sldMasterIdLst>'

--- a/src/pptxgen.ts
+++ b/src/pptxgen.ts
@@ -311,6 +311,15 @@ export default class PptxGenJS implements IPresentationProps {
 		return this._shapes
 	}
 
+	private _firstSlideNum = 1
+	public get firstSlideNum (): number {
+		return this._firstSlideNum
+	}
+
+	public set firstSlideNum (val: number) {
+		this._firstSlideNum = val
+	}
+
 	constructor () {
 		const layout4x3: PresLayout = { name: 'screen4x3', width: 9144000, height: 6858000 }
 		const layout16x9: PresLayout = { name: 'screen16x9', width: 9144000, height: 5143500 }


### PR DESCRIPTION
In some application scenarios, such as report cover, table of contents, etc., page numbers do not need to be displayed, while the main text needs to display page numbers starting from 1.

This simple feature allows users to set the starting page number to adapt to the above application scenarios.