### PR TITLE
Fixes for chart issues in keynote mac

### DIFF
--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -217,7 +217,11 @@ export async function createExcelWorksheet (chartObject: ISlideRelChart, zip: JS
 					strTableXml += `<tableColumn id="${idx + 1}" name="${idx === 0 ? 'X-Values' : 'Y-Value '}${idx}"/>`
 				})
 			} else {
-				strTableXml += `<table xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" id="1" name="Table1" displayName="Table1" ref="A1:${getExcelColName(data.length + data[0].labels.length)}${data[0].labels[0].length + 1}'" totalsRowShown="0">`
+				strTableXml +=
+					'<table xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" id="1" name="Table1" displayName="Table1" ref="A1:' +
+					getExcelColName(data.length + data[0].labels.length) +
+					(data[0].labels[0].length + 1) +
+					'" totalsRowShown="0">'
 				strTableXml += `<tableColumns count="${data.length + data[0].labels.length}">`
 				data[0].labels.forEach((_labelsGroup, idx) => {
 					strTableXml += `<tableColumn id="${idx + 1}" name="Column${idx + 1}"/>`


### PR DESCRIPTION
**Fix Issue #1306**
**Fix Issue #1242**

The problem is that the the graphs are not opened in keynote

**Issue Category**
Bug

**Product Versions**
"pptxgenjs": "3.13.0-beta.1"

**Desired Behavior**
It should show graphs in mac keynote

**Observed Behavior**
I have a ppt generated with node.js. It has charts in it. The charts are shown in microsoft powerpoint but not shown in mac keynote.

I've fixed this in a fork and creating a pull request

<img width="630" alt="image" src="https://github.com/gitbrent/PptxGenJS/assets/16374263/83826317-3e32-4173-ada2-c1d43c71d5f4">

<img width="643" alt="image" src="https://github.com/gitbrent/PptxGenJS/assets/16374263/b933c5aa-8e38-40d3-9fc4-d6a0cbc2185b">

