### PR TITLE
Fix multi lvl categories in embedded .xlsx

### DIFF
--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -135,8 +135,8 @@ export async function createExcelWorksheet (chartObject: ISlideRelChart, zip: JS
 			)
 		}
 
-		// dictionary of shared strings mapped to indexes
-		const sharedStrings: Record<string, number> = {}
+		// dictionary of shared strings mapped to their indexes indexes
+		const sharedStringsObject: Record<string, number> = {}
 
 		// sharedStrings.xml
 		{
@@ -151,7 +151,7 @@ export async function createExcelWorksheet (chartObject: ISlideRelChart, zip: JS
 				data[0].labels.forEach(arrLabel => (totCount += arrLabel.filter(label => label && label !== '').length))
 				strSharedStrings += `<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="${totCount}" uniqueCount="${totCount}">`
 				strSharedStrings += '<si><t/></si>'
-				sharedStrings[''] = 0
+				sharedStringsObject[''] = 0
 			} else {
 				// series names + all labels of one series + number of label groups (data.labels.length) of one series (i.e. how many times the blank string is used)
 				const totCount = data.length + data[0].labels.length * data[0].labels[0].length + data[0].labels.length
@@ -161,33 +161,36 @@ export async function createExcelWorksheet (chartObject: ISlideRelChart, zip: JS
 				strSharedStrings += `<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="${totCount}" uniqueCount="${unqCount}">`
 				// B: Add 'blank' for A1, B1, ..., of every label group inside data[n].labels
 				strSharedStrings += '<si><t xml:space="preserve"></t></si>'
-				sharedStrings[''] = 0
+				sharedStringsObject[''] = 0
 			}
 
 			// C: Add `name`/Series
 			if (chartObject.opts._type === CHART_TYPE.BUBBLE || chartObject.opts._type === CHART_TYPE.BUBBLE3D) {
 				data.forEach((objData, idx) => {
 					if (idx === 0) {
-						const xAxisSharedString = 'X-Axis'
-						strSharedStrings += `<si><t>${xAxisSharedString}</t></si>`
+						const sharedString = 'X-Axis'
+						if (!sharedStringsObject[sharedString]) {
+							strSharedStrings += `<si><t>${sharedString}</t></si>`
+							sharedStringsObject[sharedString] = Object.keys(sharedStringsObject).length
+						}
 					} else {
-						const yAxisSharedString = encodeXmlEntities(objData.name || `Y-Axis${idx}`)
-						if (!sharedStrings[yAxisSharedString]) {
-							strSharedStrings += `<si><t>${yAxisSharedString}</t></si>`
-							sharedStrings[yAxisSharedString] = Object.keys(yAxisSharedString).length
+						const sharedString = encodeXmlEntities(objData.name || `Y-Axis${idx}`)
+						if (!sharedStringsObject[sharedString]) {
+							strSharedStrings += `<si><t>${sharedString}</t></si>`
+							sharedStringsObject[sharedString] = Object.keys(sharedStringsObject).length
 						}
 
 						const sizeSharedString = encodeXmlEntities(`Size${idx}`)
 						strSharedStrings += `<si><t>${sizeSharedString}</t></si>`
-						sharedStrings[sizeSharedString] = Object.keys(sizeSharedString).length
+						sharedStringsObject[sizeSharedString] = Object.keys(sharedStringsObject).length
 					}
 				})
 			} else {
 				data.forEach(objData => {
 					const sharedString = encodeXmlEntities((objData.name || ' ').replace('X-Axis', 'X-Values'))
-					if (!sharedStrings[sharedString]) {
+					if (!sharedStringsObject[sharedString]) {
 						strSharedStrings += `<si><t>${sharedString}</t></si>`
-						sharedStrings[sharedString] = Object.keys(sharedStrings).length
+						sharedStringsObject[sharedString] = Object.keys(sharedStringsObject).length
 					}
 				})
 			}
@@ -203,9 +206,9 @@ export async function createExcelWorksheet (chartObject: ISlideRelChart, zip: JS
 							.filter(label => label && label !== '')
 							.forEach(label => {
 								const sharedString = encodeXmlEntities(label)
-								if (!sharedStrings[sharedString]) {
+								if (!sharedStringsObject[sharedString]) {
 									strSharedStrings += `<si><t>${sharedString}</t></si>`
-									sharedStrings[sharedString] = Object.keys(sharedStrings).length
+									sharedStringsObject[sharedString] = Object.keys(sharedStringsObject).length
 								}
 							})
 					})
@@ -492,7 +495,7 @@ export async function createExcelWorksheet (chartObject: ISlideRelChart, zip: JS
 						     */
 							const colLabel = labelsGroup[idx]
 							if (colLabel) {
-								strSheetXml += `<c r="${getExcelColName(idy + 1)}${idx + 2}" t="s"><v>${sharedStrings[colLabel]}</v></c>`
+								strSheetXml += `<c r="${getExcelColName(idy + 1)}${idx + 2}" t="s"><v>${sharedStringsObject[colLabel]}</v></c>`
 							}
 						})
 

--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -172,8 +172,11 @@ export async function createExcelWorksheet (chartObject: ISlideRelChart, zip: JS
 						strSharedStrings += `<si><t>${xAxisSharedString}</t></si>`
 					} else {
 						const yAxisSharedString = encodeXmlEntities(objData.name || `Y-Axis${idx}`)
-						strSharedStrings += `<si><t>${yAxisSharedString}</t></si>`
-						sharedStrings[yAxisSharedString] = Object.keys(yAxisSharedString).length
+						if (!sharedStrings[yAxisSharedString]) {
+							strSharedStrings += `<si><t>${yAxisSharedString}</t></si>`
+							sharedStrings[yAxisSharedString] = Object.keys(yAxisSharedString).length
+						}
+
 						const sizeSharedString = encodeXmlEntities(`Size${idx}`)
 						strSharedStrings += `<si><t>${sizeSharedString}</t></si>`
 						sharedStrings[sizeSharedString] = Object.keys(sizeSharedString).length
@@ -182,8 +185,10 @@ export async function createExcelWorksheet (chartObject: ISlideRelChart, zip: JS
 			} else {
 				data.forEach(objData => {
 					const sharedString = encodeXmlEntities((objData.name || ' ').replace('X-Axis', 'X-Values'))
-					strSharedStrings += `<si><t>${sharedString}</t></si>`
-					sharedStrings[sharedString] = Object.keys(sharedStrings).length
+					if (!sharedStrings[sharedString]) {
+						strSharedStrings += `<si><t>${sharedString}</t></si>`
+						sharedStrings[sharedString] = Object.keys(sharedStrings).length
+					}
 				})
 			}
 
@@ -197,8 +202,11 @@ export async function createExcelWorksheet (chartObject: ISlideRelChart, zip: JS
 						labelsGroup
 							.filter(label => label && label !== '')
 							.forEach(label => {
-								strSharedStrings += `<si><t>${encodeXmlEntities(label)}</t></si>`
-								sharedStrings[encodeXmlEntities(label)] = Object.keys(sharedStrings).length
+								const sharedString = encodeXmlEntities(label)
+								if (!sharedStrings[sharedString]) {
+									strSharedStrings += `<si><t>${sharedString}</t></si>`
+									sharedStrings[sharedString] = Object.keys(sharedStrings).length
+								}
 							})
 					})
 			}
@@ -484,7 +492,7 @@ export async function createExcelWorksheet (chartObject: ISlideRelChart, zip: JS
 						     */
 							const colLabel = labelsGroup[idx]
 							if (colLabel) {
-								strSheetXml += `<c r="${getExcelColName(1 + idy)}${idx + 2}" t="s"><v>${sharedStrings[colLabel]}</v></c>`
+								strSheetXml += `<c r="${getExcelColName(idy + 1)}${idx + 2}" t="s"><v>${sharedStrings[colLabel]}</v></c>`
 							}
 						})
 


### PR DESCRIPTION
## Change Summary
A key/value object was added for shared strings so that it can be used to fetch the sharedString index of category axes and removed an unneeded summand when calculating a label's column.

## Change Description

### Calculating the col and row position of the category labels

`getExcelColName(idx + 1 + idy)` did not need `idx`, and caused each subsequent row of labels to be shifted one more column to the right from the previous row.

### Calculating the category label indexes in sharedStrings.xml

I could not find a fix for the calculation, so I instead create a key/value object (e.g. `{ 'Category Label': 4 }`) that maps strings to their respective indexes in sharedStrings.xml, and use it to get the correct index of any given string.

### Other

There is at least one `WIP: FIXME:` note around this code; I did not remove it, as I wasn't sure if the note was referencing this issue in particular.

Lastly, I only updated the accessing of shared strings for `IS_MULTI_CAT_AXES`, as I'm not too familiar with the other chart types and I'd risk introducing more bugs. The dictionary object should get correctly populated by all chart types, though.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Motivation and Context
While the PPTX charts with multiple category axes looked fine, their embedded Excel contained malformed data, and upon opening the Excel, the related chart would also break.

## Checklist before requesting a review

- [ ] If it is a core feature, I have added new code under `/demos/modules/`
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new eslint warnings
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have included code/tests that prove my fix is effective or that my feature works
	- The existing demos can be run to see that the fix works
- [x] I have used the "Run All Demos" feature on the [browser demo](/demos/browser/index.html) and no errors were found
	- I couldn't get the browser demos to run, so I ran the node demos instead

## Screenshots / Sample Code (if appropriate)

| Before | After |
| --- | --- |
| ![Microsoft_Excel_Worksheet64_broken](https://github.com/gitbrent/PptxGenJS/assets/91089839/af0e3b2b-6270-4613-a37c-fc574d3e31e8) | ![Microsoft_Excel_Worksheet64](https://github.com/gitbrent/PptxGenJS/assets/91089839/d22f91ba-b849-4f0c-9946-a5363ef44de6)

