### PR TITLE
Charts with a single category axis discard values of zero

### DIFF
--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -375,7 +375,7 @@ export async function createExcelWorksheet (chartObject: ISlideRelChart, zip: JS
 							strSheetXml += '</c>'
 						}
 						for (let idy = 0; idy < data.length; idy++) {
-							strSheetXml += `<c r="${getExcelColName(data[0].labels.length + idy + 1)}${idx + 2}"><v>${data[idy].values[idx] || ''}</v></c>`
+							strSheetXml += `<c r="${getExcelColName(data[0].labels.length + idy + 1)}${idx + 2}"><v>${data[idy].values[idx] ?? ''}</v></c>`
 						}
 						strSheetXml += '</row>'
 					})


### PR DESCRIPTION
## Change Summary

Values of zero are now inserted in excel data cells for charts with a single category axis.

## Change Description

The existing logic for inserting data values into Excel cells, simplified as
```xml
<c r="A1">
  <v>${dataValue || ''}</v>
</c>
```
would not add values of 0 to the Excel table, causing cutoff points for line charts that had this value in them. This was changed to only exclude nullish values:
```xml
<c r="A1">
  <v>${dataValue ?? ''}</v>
</c>
```

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Motivation and Context

Charts with explicitly one category axis (`!IS_MULTI_CAT_AXES`), particularly line charts, would get split in two at plot points with values of zero, because its respective Excel cell would have no value inside it, instead of the expected zero number. This would only happen upon opening the embedded Excel file, as the XML of the pptx chart was written correctly.

## Checklist before requesting a review

- [ ] If it is a core feature, I have added new code under `/demos/modules/`
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new eslint warnings
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have included code/tests that prove my fix is effective or that my feature works
	- The existing demos can be run to see that the fix works
- [x] I have used the "Run All Demos" feature on the [browser demo](/demos/browser/index.html) and no errors were found
	- I couldn't get the browser demos to run, so I ran the node demos instead