### PR TITLE
chore: add custGeom "custom geometry" to types for shapes

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -240,6 +240,7 @@ declare namespace PptxGenJS {
 		'curvedLeftArrow' = 'curvedLeftArrow',
 		'curvedRightArrow' = 'curvedRightArrow',
 		'curvedUpArrow' = 'curvedUpArrow',
+		'custGeom' = 'custGeom',
 		'decagon' = 'decagon',
 		'diagStripe' = 'diagStripe',
 		'diamond' = 'diamond',
@@ -440,6 +441,7 @@ declare namespace PptxGenJS {
 		CURVED_RIGHT_ARROW = 'curvedRightArrow',
 		CURVED_UP_ARROW = 'curvedUpArrow',
 		CURVED_UP_RIBBON = 'ellipseRibbon2',
+		CUSTOM_GEOMETRY = 'custGeom',
 		DECAGON = 'decagon',
 		DIAGONAL_STRIPE = 'diagStripe',
 		DIAMOND = 'diamond',
@@ -676,6 +678,7 @@ declare namespace PptxGenJS {
 		| 'curvedLeftArrow'
 		| 'curvedRightArrow'
 		| 'curvedUpArrow'
+		| 'custGeom'
 		| 'decagon'
 		| 'diagStripe'
 		| 'diamond'


### PR DESCRIPTION
This PR adds the types needed to actually get TypeScript support when inserting custom geometry as shown in this demo: https://github.com/gitbrent/PptxGenJS/blob/master/demos/modules/demo_shape.mjs

@gitbrent Can we include this in a new release so we don’t have to monkey patch the types in our implementation?