### PR TITLE
Fixed can't selected outEnd for pie charts

### DIFF
--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -1574,7 +1574,7 @@ function makeChartType (chartType: CHART_NAME, data: IOptsChartData[], opts: ICh
 			strXml += '        </a:pPr>'
 			strXml += '      </a:p>'
 			strXml += '    </c:txPr>'
-			strXml += chartType === CHART_TYPE.PIE ? '<c:dLblPos val="ctr"/>' : ''
+			strXml += chartType === CHART_TYPE.PIE ? `<c:dLblPos val="${opts.dataLabelPosition ?? 'ctr'}"/>` : ''
 			strXml += '    <c:showLegendKey val="0"/>'
 			strXml += '    <c:showVal val="0"/>'
 			strXml += '    <c:showCatName val="1"/>'


### PR DESCRIPTION
When you try to select outEnd for the dataLabelPosition attribute, it always sets one of the 4 values on the xml as a ctr.