### PR TITLE
allows each subchart in the combo chart to react to the parameter showLegend

### DIFF
--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -725,6 +725,19 @@ export function makeXmlCharts (rel: ISlideRelChart): string {
 				strXml += '  </a:p>'
 				strXml += '</c:txPr>'
 			}
+			if (Array.isArray(rel.opts._type)) {
+				rel.opts._type.forEach(type => {
+					const showLegend = type.options.showLegend
+					if (!showLegend) {
+						type.data.forEach(obj => {
+							strXml += '    <c:legendEntry>'
+							strXml += `        <c:idx val="${obj._dataIndex}"/>`
+							strXml += '        <c:delete val="1"/>'
+							strXml += '    </c:legendEntry>'
+						})
+					}
+				})
+			}
 			strXml += '</c:legend>'
 		}
 	}


### PR DESCRIPTION
 If the legend is active in the combo chart, but the parameter showLegend is false in one of the subcharts, then the series objects of this subchart are excluded from the legend

This is very practical if both subcharts have the same data array, which means that the same series items appear twice in the legend

```
const comboOptions = {

        /** orientation/ grouping*/
        barDir: chartOrientation,
        barGrouping: barGrouping,

        /** legend */
        showLegend: true,  // LEGEND IS ACTIVE
        legendPos: 'b'
      }

const comboCharts = [
        {
          type: this.pptx.ChartType.line,
          data: data,
          options: {
            showLegend: true // SERIES LABELS FROM THE LINE ARE GOING TO BE DISPLAYED
          }
        },
        {
          type: this.pptx.ChartType.area,
          data: data,
          options: {
            showLegend: false // SERIES LABELS FROM THE AREA ARE HIDDEN
          }
        }
      ]
```