### PR TITLE
Fix in order to make images compatible with web workers

### DIFF
--- a/src/pptxgen.ts
+++ b/src/pptxgen.ts
@@ -599,6 +599,10 @@ export default class PptxGenJS implements IPresentationProps {
 	 * @returns {Promise<string>} the presentation name
 	 */
 	async writeFile (props?: WriteFileProps | string): Promise<string> {
+		let isWorker = false
+		if (typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) {
+			isWorker = true
+		}
 		const fs = typeof require !== 'undefined' && typeof window === 'undefined' ? require('fs') : null // NodeJS
 		// DEPRECATED: @deprecated v3.5.0 - fileName - [[remove in v4.0.0]]
 		if (typeof props === 'string') console.log('Warning: `writeFile(filename)` is deprecated - please use `WriteFileProps` argument (v3.5.0)')
@@ -608,9 +612,9 @@ export default class PptxGenJS implements IPresentationProps {
 
 		return await this.exportPresentation({
 			compression: propsCompress,
-			outputType: fs ? 'nodebuffer' : null,
+			outputType: (fs && !isWorker) ? 'nodebuffer' : null,
 		}).then(async content => {
-			if (fs) {
+			if (fs && !isWorker) {
 				// Node: Output
 				return await new Promise<string>((resolve, reject) => {
 					fs.writeFile(fileName, content, err => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,13 +5,13 @@
     "baseUrl": "./node_modules",
     "declaration": true,
     "declarationDir": "./out/defs",
-    "lib": ["dom", "es2015", "es2017.object"],
+    "lib": ["webworker", "dom", "es2015", "es2017.object"],
     "module": "es6",
     "moduleResolution": "node",
     "noImplicitAny": false,
     "outDir": "./out",
     "sourceMap": true,
-    "target": "es5"
+    "target": "es6"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
The code meant to detect nodejs in gen-media.ts and pptxgen.ts is mistaking web workers for nodejs and crashes. 

```ts
export function encodeSlideMediaRels (layout: PresSlide | SlideLayout): Array<Promise<string>> {
    const fs = typeof require !== 'undefined' && typeof window === 'undefined' ? require('fs') : null // NodeJS
    const https = typeof require !== 'undefined' && typeof window === 'undefined' ? require('https') : null // NodeJS

.....
```

require('fs') returns a Proxy in the context of a web worker which happens to be true-ish in the tests that are following the code snippet above. The code then tries to use fs, which obviously fails and shouldn't be used in the context of a web browser.

This pull request adds a new check to differentiate web workers from the rest of the execution :
```ts
let isWorker = false
if (typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) {
	isWorker = true
}
```
I have also added the "webworker" lib in tsconfig.json.


Unfortunately only PNG images work, due to how SVGs are rendered (similar to node).
Function writeFile() does not work either with web workers, users should use the write() function instead.