### PR TITLE
Fix table header row for accessibility

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/pptxgenjs.iml" filepath="$PROJECT_DIR$/.idea/pptxgenjs.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/pptxgenjs.iml
+++ b/.idea/pptxgenjs.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -42,6 +42,8 @@ import {
 	inch2Emu,
 	valToPts,
 } from './gen-utils'
+import PptxGenJS from "../types";
+import TableToSlidesProps = PptxGenJS.TableToSlidesProps;
 
 const ImageSizingXml = {
 	cover: function (imgSize: { w: number, h: number }, boxDim: { w: number, h: number, x: number, y: number }) {
@@ -179,7 +181,17 @@ function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 					'</p:nvGraphicFramePr>'
 				strXml += `<p:xfrm><a:off x="${x || (x === 0 ? 0 : EMU)}" y="${y || (y === 0 ? 0 : EMU)}"/><a:ext cx="${cx || (cx === 0 ? 0 : EMU)}" cy="${cy || EMU
 				}"/></p:xfrm>`
-				strXml += '<a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table"><a:tbl><a:tblPr/>'
+
+				// Bob Dolan 2025-01-27
+				// strXml += '<a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table"><a:tbl><a:tblPr/>'
+				// if autoPageRepeatHeader is true, first row of table should be marked as a header row to improve accessibility and to pass PowerPoint accessibility review
+				strXml += '<a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table"><a:tbl><a:tblPr'
+				if ((objTabOpts as TableToSlidesProps).autoPageRepeatHeader) {
+					strXml += ' firstRow="1"'
+				}
+				strXml += '/>'
+				// Bob Dolan 2025-01-27
+
 				// + '        <a:tblPr bandRow="1"/>';
 				// TODO: Support banded rows, first/last row, etc.
 				// NOTE: Banding, etc. only shows when using a table style! (or set alt row color if banding)


### PR DESCRIPTION
The accessibility checker built into PowerPoint reports that all tables generated by PPTxGenJS are "Missing Table Header" even the options are set to {autoPage:true, autoPageRepeatHeader:true}. The top row of the table indeed acts like a header visually, but not semantically as far as PowerPoint is concerned. As such, the PPTs fail accessibility testing and are inaccessible for users of assistive technologies such as screen readers. 

A simple—and perhaps overly simple—solution was implemented here such that if autoPageRepeatHeader is true, the first row of the table is marked up as a header row when the XML is generated for the PowerPoint file.

Reference issue # 1299 (https://github.com/gitbrent/PptxGenJS/issues/1299)