### PR TITLE
Fix table header row for accessibility (Issue #1299)

### DIFF
--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -43,6 +43,11 @@ import {
 	valToPts,
 } from './gen-utils'
 
+// Bob Dolan 2025-01-27 | Issue #1299
+import PptxGenJS from '../types'
+import TableToSlidesProps = PptxGenJS.TableToSlidesProps
+// Bob Dolan 2025-01-27 | Issue #1299
+
 const ImageSizingXml = {
 	cover: function (imgSize: { w: number, h: number }, boxDim: { w: number, h: number, x: number, y: number }) {
 		const imgRatio = imgSize.h / imgSize.w
@@ -179,7 +184,17 @@ function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 					'</p:nvGraphicFramePr>'
 				strXml += `<p:xfrm><a:off x="${x || (x === 0 ? 0 : EMU)}" y="${y || (y === 0 ? 0 : EMU)}"/><a:ext cx="${cx || (cx === 0 ? 0 : EMU)}" cy="${cy || EMU
 				}"/></p:xfrm>`
-				strXml += '<a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table"><a:tbl><a:tblPr/>'
+
+				// Bob Dolan 2025-01-27 | Issue #1299
+				// strXml += '<a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table"><a:tbl><a:tblPr/>'
+				// if autoPageRepeatHeader is true, first row of table should be marked as a header row to improve accessibility and to pass PowerPoint accessibility review
+				strXml += '<a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table"><a:tbl><a:tblPr'
+				if ((objTabOpts as TableToSlidesProps).autoPageRepeatHeader) {
+					strXml += ' firstRow="1"'
+				}
+				strXml += '/>'
+				// Bob Dolan 2025-01-27 | Issue #1299
+
 				// + '        <a:tblPr bandRow="1"/>';
 				// TODO: Support banded rows, first/last row, etc.
 				// NOTE: Banding, etc. only shows when using a table style! (or set alt row color if banding)


### PR DESCRIPTION
The accessibility checker built into PowerPoint reports that all tables generated by PPTxGenJS are "Missing Table Header" even the options are set to {autoPage:true, autoPageRepeatHeader:true}. The top row of the table indeed acts like a header visually, but not semantically as far as PowerPoint is concerned. As such, the PPTs fail accessibility testing and are inaccessible for users of assistive technologies such as screen readers. 

A simple—and perhaps overly simple—solution was implemented here such that if autoPageRepeatHeader is true, the first row of the table is marked up as a header row when the XML is generated for the PowerPoint file.

Reference issue # 1299 (https://github.com/gitbrent/PptxGenJS/issues/1299)
