### PR TITLE
Remove unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,14 @@
 {
 	"name": "pptxgenjs",
-	"version": "4.0.1-beta.0",
+	"version": "4.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pptxgenjs",
-			"version": "4.0.1-beta.0",
+			"version": "4.0.1",
 			"license": "MIT",
 			"dependencies": {
-				"@types/node": "^22.8.1",
-				"https": "^1.0.0",
 				"image-size": "^1.2.1",
 				"jszip": "^3.10.1"
 			},
@@ -19,6 +17,7 @@
 				"@rollup/plugin-commonjs": "^28.0.1",
 				"@rollup/plugin-node-resolve": "^16.0.1",
 				"@stylistic/eslint-plugin": "^4.2.0",
+				"@types/node": "^22.8.1",
 				"@typescript-eslint/eslint-plugin": "^8.31.0",
 				"@typescript-eslint/parser": "^8.31.0",
 				"eslint": "^9.25.1",
@@ -843,6 +842,7 @@
 			"version": "22.14.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
 			"integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.21.0"
@@ -3584,12 +3584,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/https": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
-			"integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==",
-			"license": "ISC"
-		},
 		"node_modules/iconv-lite": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -6057,6 +6051,7 @@
 			"version": "6.21.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
 			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -38,8 +38,6 @@
 		"path": false
 	},
 	"dependencies": {
-		"@types/node": "^22.8.1",
-		"https": "^1.0.0",
 		"image-size": "^1.2.1",
 		"jszip": "^3.10.1"
 	},
@@ -48,6 +46,7 @@
 		"@rollup/plugin-commonjs": "^28.0.1",
 		"@rollup/plugin-node-resolve": "^16.0.1",
 		"@stylistic/eslint-plugin": "^4.2.0",
+		"@types/node": "^22.8.1",
 		"@typescript-eslint/eslint-plugin": "^8.31.0",
 		"@typescript-eslint/parser": "^8.31.0",
 		"eslint": "^9.25.1",


### PR DESCRIPTION
Remove the `https` dependency because it's not used. Only the native Node.js `https` package is used. The `https` package on npm is a dummy package anyway.

Move the `@types/node` dependency to devDependencies because it's only needed for development. When this package is used in a TypeScript project, this project will have its own version of `@types/node` installed.