### PR TITLE
Add missing XML encoding to company attribute

### DIFF
--- a/demos/modules/enums.mjs
+++ b/demos/modules/enums.mjs
@@ -8,7 +8,7 @@ export const TESTMODE = typeof window !== "undefined" && window.location && wind
 export const COMPRESS = true; // TEST: `compression` write prop
 
 // CONST
-export const CUST_NAME = "S.T.A.R. Laboratories";
+export const CUST_NAME = "S.T.A.R. Laboratories & co";
 export const USER_NAME = "Barry Allen";
 export const ARRSTRBITES = [130];
 export const CHARSPERLINE = 130; // "Open Sans", 13px, 900px-colW = ~19 words/line ~130 chars/line

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -1495,7 +1495,7 @@ export function makeXmlApp (slides: PresSlide[], company: string): string {
 			${slides.map((_slideObj, idx) => `<vt:lpstr>Slide ${idx + 1}</vt:lpstr>`).join('')}
 		</vt:vector>
 	</TitlesOfParts>
-	<Company>${company}</Company>
+	<Company>${encodeXmlEntities(company)}</Company>
 	<LinksUpToDate>false</LinksUpToDate>
 	<SharedDoc>false</SharedDoc>
 	<HyperlinksChanged>false</HyperlinksChanged>


### PR DESCRIPTION
Fixes error "PowerPoint found a problem with content in [path to generated file]" when opening the generated file if there are xml character entities in the "company" attribute.