### PR TITLE
[BUG FIX] Scatter and Bubble chart formatting fix

### DIFF
--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -1664,7 +1664,7 @@ function makeCatAxis (opts: IChartOptsLib, axisId: string, valAxisId: string): s
 	}
 	// NOTE: Adding Val Axis Formatting if scatter or bubble charts
 	if (opts._type === CHART_TYPE.SCATTER || opts._type === CHART_TYPE.BUBBLE || opts._type === CHART_TYPE.BUBBLE3D) {
-		strXml += '  <c:numFmt formatCode="' + (opts.valAxisLabelFormatCode ? encodeXmlEntities(opts.valAxisLabelFormatCode) : 'General') + '" sourceLinked="1"/>'
+		strXml += '  <c:numFmt formatCode="' + (opts.catLabelFormatCode ? encodeXmlEntities(opts.catLabelFormatCode) : 'General') + '" sourceLinked="1"/>'
 	} else {
 		strXml += '  <c:numFmt formatCode="' + (encodeXmlEntities(opts.catLabelFormatCode) || 'General') + '" sourceLinked="1"/>'
 	}


### PR DESCRIPTION
I have changed the categorical axis formatting for the scatter and bubble charts to use the catLabelFormatCode parameter. The original implementation used valAxisLabelFormatCode, which is also applied to the value axis. Since both parameters use standard formatting encodings, the categorical axis (x-axis) for scatter and bubble charts can instead use the catLabelFormatCode parameter. This allows for separate formatting of the x- and y-axes for scatter and bubble charts. This fixes issue #1436.

I have only included the src/ file to prevent any conflicts. Let me know if I need to run the pipeline locally and update the other files.