### PR TITLE
Fix placeholder replacement bug

### DIFF
--- a/src/gen-objects.ts
+++ b/src/gen-objects.ts
@@ -1126,7 +1126,7 @@ export function addPlaceholdersToSlideLayouts(slide: PresSlide): void {
 			// NOTE: Check to ensure a placeholder does not already exist on the Slide
 			// They are created when they have been populated with text (ex: `slide.addText('Hi', { placeholder:'title' });`)
 			if (slide._slideObjects.filter(slideObj => slideObj.options && slideObj.options.placeholder === slideLayoutObj.options.placeholder).length === 0) {
-				addTextDefinition(slide, [{ text: '' }], slideLayoutObj.options, false)
+				addTextDefinition(slide, [{ text: '' }], slideLayoutObj.options, true)
 			}
 		}
 	})


### PR DESCRIPTION
When using slide masters with placeholders, empty placeholders were incorrectly created as TEXT objects instead of PLACEHOLDER objects. This caused unwanted 'Click to add text' boxes to appear in generated presentations even when placeholders were intentionally left empty.

The fix changes the isPlaceholder parameter from false to true in addPlaceholdersToSlideLayouts() function, ensuring empty placeholders are created with the correct object type.

This prevents the XML generator from rendering empty placeholders as visible content, eliminating the 'Click to add text' boxes.