### PR TITLE
Add gradient fill support for shapes

### DIFF
--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -171,6 +171,27 @@ export interface ShadowProps {
 	 */
 	rotateWithShape?: boolean
 }
+// Gradient stop for linear gradients
+export interface GradientStop {
+	/**
+	 * Stop position (0-100, as percentage)
+	 * @example 0 // start of gradient
+	 * @example 50 // middle
+	 * @example 100 // end of gradient
+	 */
+	position: number
+	/**
+	 * Stop color (hex format without #)
+	 * @example 'FF0000' // red
+	 */
+	color: HexColor
+	/**
+	 * Stop transparency (0-100, optional)
+	 * @default 0
+	 */
+	transparency?: number
+}
+
 // used by: shape, table, text
 export interface ShapeFillProps {
 	/**
@@ -191,7 +212,24 @@ export interface ShapeFillProps {
 	 * Fill type
 	 * @default 'solid'
 	 */
-	type?: 'none' | 'solid'
+	type?: 'none' | 'solid' | 'gradient'
+	/**
+	 * Gradient type (only used when type is 'gradient')
+	 * @default 'linear'
+	 */
+	gradientType?: 'linear'
+	/**
+	 * Gradient rotation angle in degrees (only used when type is 'gradient')
+	 * - 0 = left to right
+	 * - 90 = top to bottom
+	 * @default 0
+	 */
+	rotate?: number
+	/**
+	 * Gradient stops (only used when type is 'gradient')
+	 * - minimum 2 stops required
+	 */
+	stops?: GradientStop[]
 
 	/**
 	 * Transparency (percent)

--- a/src/gen-utils.ts
+++ b/src/gen-utils.ts
@@ -204,6 +204,12 @@ export function genXmlColorSelection (props: Color | ShapeFillProps | ShapeLineP
 			case 'solid':
 				outText += `<a:solidFill>${createColorElement(colorVal, internalElements)}</a:solidFill>`
 				break
+			case 'gradient':
+				outText += genXmlGradientFill(props as ShapeFillProps)
+				break
+			case 'none':
+				outText += '<a:noFill/>'
+				break
 			default: // @note need a statement as having only "break" is removed by rollup, then tiggers "no-default" js-linter
 				outText += ''
 				break
@@ -211,6 +217,37 @@ export function genXmlColorSelection (props: Color | ShapeFillProps | ShapeLineP
 	}
 
 	return outText
+}
+
+/**
+ * Generate gradient fill XML
+ * @param {ShapeFillProps} props fill props with gradient settings
+ * @returns XML string for gradient fill
+ */
+function genXmlGradientFill (props: ShapeFillProps): string {
+	if (!props.stops || props.stops.length < 2) {
+		// Fallback to solid fill if no valid stops
+		return props.color ? `<a:solidFill>${createColorElement(props.color)}</a:solidFill>` : ''
+	}
+
+	// OOXML uses 60000ths of a degree for angles
+	const angle = (props.rotate || 0) * 60000
+
+	let stopsXml = ''
+	for (const stop of props.stops) {
+		// Position is in 1/1000ths of a percent (0-100000)
+		const pos = Math.round(stop.position * 1000)
+		const color = (stop.color || '000000').replace('#', '')
+		let alphaXml = ''
+		if (stop.transparency && stop.transparency > 0) {
+			// Transparency: 0 = opaque, 100 = fully transparent
+			// Alpha value: 100000 = opaque, 0 = fully transparent
+			alphaXml = `<a:alpha val="${Math.round((100 - stop.transparency) * 1000)}"/>`
+		}
+		stopsXml += `<a:gs pos="${pos}"><a:srgbClr val="${color}">${alphaXml}</a:srgbClr></a:gs>`
+	}
+
+	return `<a:gradFill><a:gsLst>${stopsXml}</a:gsLst><a:lin ang="${angle}" scaled="1"/></a:gradFill>`
 }
 
 /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -999,6 +999,27 @@ declare namespace PptxGenJS {
 		 */
 		rotateWithShape?: boolean
 	}
+	// Gradient stop for linear gradients
+	export interface GradientStop {
+		/**
+		 * Stop position (0-100, as percentage)
+		 * @example 0 // start of gradient
+		 * @example 50 // middle
+		 * @example 100 // end of gradient
+		 */
+		position: number
+		/**
+		 * Stop color (hex format without #)
+		 * @example 'FF0000' // red
+		 */
+		color: HexColor
+		/**
+		 * Stop transparency (0-100, optional)
+		 * @default 0
+		 */
+		transparency?: number
+	}
+
 	// used by: shape, table, text
 	export interface ShapeFillProps {
 		/**
@@ -1019,7 +1040,24 @@ declare namespace PptxGenJS {
 		 * Fill type
 		 * @default 'solid'
 		 */
-		type?: 'none' | 'solid'
+		type?: 'none' | 'solid' | 'gradient'
+		/**
+		 * Gradient type (only used when type is 'gradient')
+		 * @default 'linear'
+		 */
+		gradientType?: 'linear'
+		/**
+		 * Gradient rotation angle in degrees (only used when type is 'gradient')
+		 * - 0 = left to right
+		 * - 90 = top to bottom
+		 * @default 0
+		 */
+		rotate?: number
+		/**
+		 * Gradient stops (only used when type is 'gradient')
+		 * - minimum 2 stops required
+		 */
+		stops?: GradientStop[]
 
 		/**
 		 * Transparency (percent)


### PR DESCRIPTION
## Summary
- Adds `GradientStop` interface with position, color, and transparency properties
- Extends `ShapeFillProps` with `type: 'gradient'`, `gradientType`, `rotate`, and `stops` options
- Generates proper OOXML linear gradient XML output in `genXmlColorSelection`
- Updates TypeScript type definitions to match

## Test plan
- [ ] Verify gradient fill renders correctly in generated PPTX files
- [ ] Test with multiple gradient stops and transparency values
- [ ] Confirm backward compatibility with existing solid and none fill types