### PR TITLE
fix: inner shadow property breaks PPTX file

### DIFF
--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -528,7 +528,7 @@ function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 					strSlideXml += ` <a:${slideItemObj.options.shadow.type}Shdw ${slideItemObj.options.shadow.type === 'outer' ? 'sx="100000" sy="100000" kx="0" ky="0" algn="bl" rotWithShape="0"' : ''} blurRad="${slideItemObj.options.shadow.blur}" dist="${slideItemObj.options.shadow.offset}" dir="${slideItemObj.options.shadow.angle}">`
 					strSlideXml += ` <a:srgbClr val="${slideItemObj.options.shadow.color}">`
 					strSlideXml += ` <a:alpha val="${slideItemObj.options.shadow.opacity}"/></a:srgbClr>`
-					strSlideXml += ' </a:outerShdw>'
+					strSlideXml += ` </a:${slideItemObj.options.shadow.type}Shdw>`
 					strSlideXml += '</a:effectLst>'
 				}
 


### PR DESCRIPTION
Fix #1293 

Root cause: In src/gen-xml.ts:531, the shape shadow closing XML tag is hardcoded as </a:outerShdw> instead of using the dynamic shadow type. When 'inner' is used, the XML opens with <a:innerShdw> but closes with </a:outerShdw>, creating malformed XML that PowerPoint cannot parse.