### PR TITLE
Fix four bugs causing PowerPoint repair dialog & missing bullets (#1432, #1440, #1441, #1442)

### DIFF
--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -90,7 +90,7 @@ function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 	if (slide._bkgdImgRid) {
 		strSlideXml += `<p:bg><p:bgPr><a:blipFill dpi="0" rotWithShape="1"><a:blip r:embed="rId${slide._bkgdImgRid}"><a:lum/></a:blip><a:srcRect/><a:stretch><a:fillRect/></a:stretch></a:blipFill><a:effectLst/></p:bgPr></p:bg>`
 	} else if (slide.background?.color) {
-		strSlideXml += `<p:bg><p:bgPr>${genXmlColorSelection(slide.background)}</p:bgPr></p:bg>`
+		strSlideXml += `<p:bg><p:bgPr>${genXmlColorSelection(slide.background)}<a:effectLst/></p:bgPr></p:bg>`
 	} else if (!slide.bkgd && slide._name && slide._name === DEF_PRES_LAYOUT_NAME) {
 		// NOTE: Default [white] background is needed on slideMaster1.xml to avoid gray background in Keynote (and Finder previews)
 		strSlideXml += '<p:bg><p:bgRef idx="1001"><a:schemeClr val="bg1"/></p:bgRef></p:bg>'
@@ -319,6 +319,9 @@ function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 
 						let cellMargin = cellOpts.margin === 0 || cellOpts.margin ? cellOpts.margin : DEF_CELL_MARGIN_IN
 						if (!Array.isArray(cellMargin) && typeof cellMargin === 'number') cellMargin = [cellMargin, cellMargin, cellMargin, cellMargin]
+						// Guard against non-number, non-array values (e.g. objects or strings) that would produce NaN XML attributes and trigger the PowerPoint repair dialog
+						if (!Array.isArray(cellMargin)) cellMargin = DEF_CELL_MARGIN_IN
+						cellMargin = cellMargin.map(v => (typeof v === 'number' && isFinite(v) ? v : 0)) as [number, number, number, number]
 						/** FUTURE: DEPRECATED:
 						 * - Backwards-Compat: Oops! Discovered we were still using points for cell margin before v3.8.0 (UGH!)
 						 * - We cant introduce a breaking change before v4.0, so...
@@ -887,13 +890,11 @@ function genXmlParagraphProperties (textObj: ISlideObject | TextProps, isDefault
 		if (typeof textObj.options.bullet === 'object') {
 			if (textObj?.options?.bullet?.indent) bulletMarL = valToPts(textObj.options.bullet.indent)
 
-			if (textObj.options.bullet.type) {
-				if (textObj.options.bullet.type.toString().toLowerCase() === 'number') {
-					paragraphPropXml += ` marL="${textObj.options.indentLevel && textObj.options.indentLevel > 0 ? bulletMarL + bulletMarL * textObj.options.indentLevel : bulletMarL
-					}" indent="-${bulletMarL}"`
-					strXmlBullet = `<a:buSzPct val="100000"/><a:buFont typeface="+mj-lt"/><a:buAutoNum type="${textObj.options.bullet.style || 'arabicPeriod'}" startAt="${textObj.options.bullet.numberStartAt || textObj.options.bullet.startAt || '1'
-					}"/>`
-				}
+			if (textObj.options.bullet.type && textObj.options.bullet.type.toString().toLowerCase() === 'number') {
+				paragraphPropXml += ` marL="${textObj.options.indentLevel && textObj.options.indentLevel > 0 ? bulletMarL + bulletMarL * textObj.options.indentLevel : bulletMarL
+				}" indent="-${bulletMarL}"`
+				strXmlBullet = `<a:buSzPct val="100000"/><a:buFont typeface="+mj-lt"/><a:buAutoNum type="${textObj.options.bullet.style || 'arabicPeriod'}" startAt="${textObj.options.bullet.numberStartAt || textObj.options.bullet.startAt || '1'
+				}"/>`
 			} else if (textObj.options.bullet.characterCode) {
 				let bulletCode = `&#x${textObj.options.bullet.characterCode};`
 
@@ -1156,8 +1157,11 @@ export function genXmlTextBody (slideObj: ISlideObject | TableCell): string {
 	let tmpTextObjects: TextProps[] = []
 	const arrTextObjects: TextProps[] = []
 
-	// FIRST: Shapes without text, etc. may be sent here during build, but have no text to render so return an empty string
-	if (opts && slideObj._type !== SLIDE_OBJECT_TYPES.tablecell && (typeof slideObj.text === 'undefined' || slideObj.text === null)) return ''
+	// FIRST: Shapes without text still require a `<p:txBody>` child per OOXML schema (ISO/IEC 29500);
+	// omitting it triggers the PowerPoint repair dialog. Return a minimal valid `<p:txBody>`.
+	if (opts && slideObj._type !== SLIDE_OBJECT_TYPES.tablecell && (typeof slideObj.text === 'undefined' || slideObj.text === null)) {
+		return `<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:endParaRPr lang="${opts.lang || 'en-US'}"/></a:p></p:txBody>`
+	}
 
 	// STEP 1: Start textBody
 	let strSlideXml = slideObj._type === SLIDE_OBJECT_TYPES.tablecell ? '<a:txBody>' : '<p:txBody>'


### PR DESCRIPTION
## Change Summary

Fixes four small bugs in `src/gen-xml.ts`, all of which are reported with reproductions and root-cause analysis in the linked issues. Three produce OOXML schema violations that trigger the PowerPoint repair dialog; one silently drops a bullet style.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Related Issues

- Closes #1432 — `bullet: { type: "bullet" }` results in no bullet
- Closes #1440 — table cell margin produces `NaN` XML attributes for invalid input
- Closes #1441 — shapes without text produce `<p:sp>` missing `<p:txBody>`
- Closes #1442 — solid color background missing `<a:effectLst/>`

## Motivation and Context

Three of these (#1440, #1441, #1442) produce OOXML schema violations that cause PowerPoint to show the "PowerPoint found a problem with content" repair dialog when opening a generated file. The fourth (#1432) makes `bullet: { type: 'bullet' }` — a documented and TypeScript-typed value (`type?: 'bullet' | 'number'`, default `'bullet'`) — silently produce no bullet. The fixes are minimal and isolated; all four root causes were already debugged by the original reporters.

## Change Description

**`gen-xml.ts:93` — Issue #1442**
Solid color background now includes `<a:effectLst/>`, matching the image-background branch one line above.

```diff
-strSlideXml += `<p:bg><p:bgPr>${genXmlColorSelection(slide.background)}</p:bgPr></p:bg>`
+strSlideXml += `<p:bg><p:bgPr>${genXmlColorSelection(slide.background)}<a:effectLst/></p:bgPr></p:bg>`
```

**`gen-xml.ts:320` — Issue #1440**
Adds two defensive guards after the existing number-to-array conversion:
- if `cellMargin` is still not an array (i.e. user passed an object or string), fall back to `DEF_CELL_MARGIN_IN`
- map any non-finite entries to `0` so `inch2Emu(undefined)` can no longer yield `marL=\"NaN\"` etc.

**`gen-xml.ts:890` — Issue #1432**
Merges the outer `if (bullet.type)` and inner `if (type === 'number')` checks into a single condition so non-number types fall through to the `characterCode` / `code` / default branches and produce a normal bullet character.

**`gen-xml.ts:1158` — Issue #1441**
`genXmlTextBody()` no longer returns an empty string when a non-tablecell object has no text; it returns a minimal valid `<p:txBody>` (`<a:bodyPr/><a:lstStyle/><a:p><a:endParaRPr lang=\"...\"/></a:p>`) so the enclosing `<p:sp>` satisfies the OOXML schema. The `lang` defaults to `opts.lang || 'en-US'`, consistent with other endParaRPr emissions in this file.

## Verification

Built locally with `npm run build` and ran a small Node script that exercises each scenario and inspects the resulting XML in the generated `.pptx`:

\`\`\`
PASS  #1442 solid bg includes <a:effectLst/>
PASS  #1441 empty-text shape has <p:txBody>
PASS  #1440 bogus table margin produces no NaN attributes
PASS  #1432 bullet:{type:\"bullet\"} renders <a:buChar>
\`\`\`

Confirmed that the same script fails on \`master\` (without the fix), and \`npx eslint src/gen-xml.ts src/gen-objects.ts\` passes clean.

## Checklist

- [x] My code follows the style guidelines of this project (tabs, single quotes, no semicolons)
- [x] My changes generate no new eslint warnings (lint clean on modified files)
- [x] I have performed a self-review of my code
- [x] I have commented the non-obvious lines (OOXML reasoning, NaN guard rationale)
- [x] I have included verification that the fixes are effective (see above)
- [x] Only `src/*.ts` modified — no `dist` or `src/bld` changes