### PR TITLE
Apply data label font properties to scatter chart dLbls XML (#1348)

### DIFF
--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -1124,7 +1124,11 @@ function makeChartType (chartType: CHART_NAME, data: IOptsChartData[], opts: ICh
 								strXml += '            <a:lstStyle/>'
 								strXml += '            <a:p>'
 								strXml += '                <a:pPr>'
-								strXml += '                    <a:defRPr/>'
+								// Emit a fully-populated defRPr so dataLabelFontSize/FontFace/Color/Bold/Italic actually take effect for scatter labels (Issue #1348)
+								strXml += `                    <a:defRPr sz="${Math.round((opts.dataLabelFontSize || DEF_FONT_SIZE) * 100)}" b="${opts.dataLabelFontBold ? 1 : 0}" i="${opts.dataLabelFontItalic ? 1 : 0}" u="none" strike="noStrike">`
+								strXml += `                        <a:solidFill>${createColorElement(opts.dataLabelColor || DEF_FONT_COLOR)}</a:solidFill>`
+								strXml += `                        <a:latin typeface="${opts.dataLabelFontFace || 'Arial'}"/>`
+								strXml += '                    </a:defRPr>'
 								strXml += '                </a:pPr>'
 								strXml += '              <a:r>'
 								strXml += '                    <a:rPr lang="' + (opts.lang || 'en-US') + '" dirty="0"/>'
@@ -1141,7 +1145,10 @@ function makeChartType (chartType: CHART_NAME, data: IOptsChartData[], opts: ICh
 									strXml += '              <a:fld id="{' + getUuid('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx') + '}" type="XVALUE">'
 									strXml += '                  <a:rPr lang="' + (opts.lang || 'en-US') + '" baseline="0"/>'
 									strXml += '                  <a:pPr>'
-									strXml += '                      <a:defRPr/>'
+									strXml += `                      <a:defRPr sz="${Math.round((opts.dataLabelFontSize || DEF_FONT_SIZE) * 100)}" b="${opts.dataLabelFontBold ? 1 : 0}" i="${opts.dataLabelFontItalic ? 1 : 0}" u="none" strike="noStrike">`
+									strXml += `                          <a:solidFill>${createColorElement(opts.dataLabelColor || DEF_FONT_COLOR)}</a:solidFill>`
+									strXml += `                          <a:latin typeface="${opts.dataLabelFontFace || 'Arial'}"/>`
+									strXml += '                      </a:defRPr>'
 									strXml += '                  </a:pPr>'
 									strXml += '                  <a:t>[' + encodeXmlEntities(obj.name) + '</a:t>'
 									strXml += '              </a:fld>'
@@ -1152,7 +1159,10 @@ function makeChartType (chartType: CHART_NAME, data: IOptsChartData[], opts: ICh
 									strXml += '              <a:fld id="{' + getUuid('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx') + '}" type="YVALUE">'
 									strXml += '                  <a:rPr lang="' + (opts.lang || 'en-US') + '" baseline="0"/>'
 									strXml += '                  <a:pPr>'
-									strXml += '                      <a:defRPr/>'
+									strXml += `                      <a:defRPr sz="${Math.round((opts.dataLabelFontSize || DEF_FONT_SIZE) * 100)}" b="${opts.dataLabelFontBold ? 1 : 0}" i="${opts.dataLabelFontItalic ? 1 : 0}" u="none" strike="noStrike">`
+									strXml += `                          <a:solidFill>${createColorElement(opts.dataLabelColor || DEF_FONT_COLOR)}</a:solidFill>`
+									strXml += `                          <a:latin typeface="${opts.dataLabelFontFace || 'Arial'}"/>`
+									strXml += '                      </a:defRPr>'
 									strXml += '                  </a:pPr>'
 									strXml += '                  <a:t>[' + encodeXmlEntities(obj.name) + ']</a:t>'
 									strXml += '              </a:fld>'
@@ -1207,7 +1217,10 @@ function makeChartType (chartType: CHART_NAME, data: IOptsChartData[], opts: ICh
 						strXml += '        <a:lstStyle/>'
 						strXml += '        <a:p>'
 						strXml += '            <a:pPr>'
-						strXml += '                <a:defRPr/>'
+						strXml += `                <a:defRPr sz="${Math.round((opts.dataLabelFontSize || DEF_FONT_SIZE) * 100)}" b="${opts.dataLabelFontBold ? 1 : 0}" i="${opts.dataLabelFontItalic ? 1 : 0}" u="none" strike="noStrike">`
+						strXml += `                    <a:solidFill>${createColorElement(opts.dataLabelColor || DEF_FONT_COLOR)}</a:solidFill>`
+						strXml += `                    <a:latin typeface="${opts.dataLabelFontFace || 'Arial'}"/>`
+						strXml += '                </a:defRPr>'
 						strXml += '            </a:pPr>'
 						strXml += '            <a:endParaRPr lang="en-US"/>'
 						strXml += '        </a:p>'


### PR DESCRIPTION
## Change Summary

Fixes #1348. Scatter charts now respect `dataLabelFontSize` / `dataLabelFontFace` / `dataLabelColor` / `dataLabelFontBold` / `dataLabelFontItalic` in PowerPoint by emitting populated `<a:defRPr>` blocks where the code previously emitted bare `<a:defRPr/>`.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Related Issue

Closes #1348 — *Scatter plot data label font size not working*

## Motivation and Context

In `src/gen-charts.ts`, the scatter chart's data-label section emits four `<a:pPr>` blocks containing bare `<a:defRPr/>` elements:

1. main label paragraph (`dataLabelFormatScatter: 'custom' | 'customXY'`)
2. X-value field paragraph (`customXY`)
3. Y-value field paragraph (`customXY`)
4. XY-format dLbls txPr paragraph (`'XY'`)

With these `<a:defRPr/>` empty, PowerPoint falls back to its own defaults for the scatter label rich text — ignoring the user-supplied `dataLabel*` chart options. Line/bar/pie data labels in the same file already emit a populated `defRPr` (see `gen-charts.ts:882-886`, `1003-1005`, `1303-1305`, etc.); the scatter chart was the only remaining holdout.

A user attached the same diff in a comment on the issue page.

## Change Description

Each of the four bare `<a:defRPr/>` emissions is replaced with the populated form already used elsewhere in this file:

```ts
strXml += `<a:defRPr sz="${Math.round((opts.dataLabelFontSize || DEF_FONT_SIZE) * 100)}" b="${opts.dataLabelFontBold ? 1 : 0}" i="${opts.dataLabelFontItalic ? 1 : 0}" u="none" strike="noStrike">`
strXml += `    <a:solidFill>${createColorElement(opts.dataLabelColor || DEF_FONT_COLOR)}</a:solidFill>`
strXml += `    <a:latin typeface="${opts.dataLabelFontFace || 'Arial'}"/>`
strXml += `</a:defRPr>`
```

When the user doesn't specify these options, the result is identical to the previous behavior (font size = `DEF_FONT_SIZE`, font face = `Arial`, color = `DEF_FONT_COLOR`, bold/italic = off, underline/strike = none) — no regression for callers that don't set the options.

## Verification

Generated a scatter chart with both `customXY` and `XY` label formats, all five `dataLabel*` font options set, and inspected the produced chart XML:

```
PASS  #1348 dataLabelFontSize=6 surfaces as sz="600"
PASS  #1348 dataLabelFontBold surfaces as b="1"
PASS  #1348 dataLabelFontItalic surfaces as i="1"
PASS  #1348 dataLabelColor surfaces as solidFill srgbClr FF0000
PASS  #1348 dataLabelFontFace surfaces as latin typeface="Courier New"
PASS  #1348 no bare empty <a:defRPr/> remain in scatter dLbls block
```

On `master` (without the fix) the bare `<a:defRPr/>` check fails — 16 empty defRPr instances remain across the two charts, matching the source of the bug. `npx eslint src/gen-charts.ts` reports the same one pre-existing warning (`isMultiTypeChart` unused), no new warnings introduced.

## Checklist

- [x] Style guidelines followed (tabs, single quotes, no semicolons)
- [x] No new eslint warnings on modified file
- [x] Self-review performed
- [x] Comment added explaining why the font properties are emitted at this level (#1348)
- [x] Verification harness confirms the fix and reproduces the bug on master
- [x] Only `src/*.ts` modified — no `dist` / `src/bld` changes