### PR TITLE
fix(makeXmlContTypes): correct jpg MIME + drop ghost slideMaster Overrides (closes #1444)

### DIFF
--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -1382,7 +1382,7 @@ export function makeXmlContTypes (slides: PresSlide[], slideLayouts: SlideLayout
 	strXml += '<Default Extension="xml" ContentType="application/xml"/>'
 	strXml += '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
 	strXml += '<Default Extension="jpeg" ContentType="image/jpeg"/>'
-	strXml += '<Default Extension="jpg" ContentType="image/jpg"/>'
+	strXml += '<Default Extension="jpg" ContentType="image/jpeg"/>'
 	strXml += '<Default Extension="svg" ContentType="image/svg+xml"/>'
 
 	// STEP 1: Add standard/any media types used in Presentation
@@ -1403,8 +1403,8 @@ export function makeXmlContTypes (slides: PresSlide[], slideLayouts: SlideLayout
 	// STEP 2: Add presentation and slide master(s)/slide(s)
 	strXml += '<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>'
 	strXml += '<Override PartName="/ppt/notesMasters/notesMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.notesMaster+xml"/>'
+	strXml += '<Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>'
 	slides.forEach((slide, idx) => {
-		strXml += `<Override PartName="/ppt/slideMasters/slideMaster${idx + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>`
 		strXml += `<Override PartName="/ppt/slides/slide${idx + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>`
 		// Add charts if any
 		slide._relsChart.forEach(rel => {


### PR DESCRIPTION
## Summary

Two long-standing bugs in `[Content_Types].xml` generation, both inside `makeXmlContTypes()` at `src/gen-xml.ts`. Both fixed in one PR because they share the same two-line region of the function and are mechanically tiny.

## Bug 1 — `image/jpg` is not an IANA-registered MIME

```diff
-	strXml += '<Default Extension="jpg" ContentType="image/jpg"/>'
+	strXml += '<Default Extension="jpg" ContentType="image/jpeg"/>'
```

`image/jpg` does not exist in the IANA registry — the valid type is `image/jpeg`. PPT files generated with `image/jpg` open in lenient parsers (PowerPoint Desktop, Keynote, LibreOffice, Google Slides) but trigger strict-mode warnings in OOXML linters and some compliance-focused parsers (e.g. SoftMaker FreeOffice). The file extension on the binary stays `.jpg`; only the MIME changes.

## Bug 2 — ghost slideMaster Overrides (closes #1444)

```diff
 strXml += '<Override PartName="/ppt/notesMasters/notesMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.notesMaster+xml"/>'
+strXml += '<Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>'
 slides.forEach((slide, idx) => {
-    strXml += `<Override PartName="/ppt/slideMasters/slideMaster${idx + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>`
     strXml += `<Override PartName="/ppt/slides/slide${idx + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>`
```

The `slides.forEach` loop currently emits one `<Override PartName="/ppt/slideMasters/slideMaster${idx + 1}.xml"/>` per slide, but PptxGenJS only ever serializes a single `slideMaster1.xml` to the zip (see `genMasterSlide()` which writes one master regardless of slide count). Result: an N-slide deck declares N slideMaster Overrides in `[Content_Types].xml` but only `slideMaster1.xml` exists on disk — N-1 ghost references.

PowerPoint Desktop tolerates this and silently ignores the ghosts. Stricter parsers report orphan Overrides; some online viewers (and PowerPoint Repair if the file is round-tripped) flag the file as corrupt and rewrite it.

The fix is structural: hoist a single literal `slideMaster1.xml` Override above the `slides.forEach` and drop the per-slide templated line. The forEach still iterates for `slides/slide${idx+1}.xml` Overrides and chart Overrides — only the slideMaster line is hoisted out.

Tracked at issue #1444 (open Feb 2026).

## Verification

Generated a 2-slide deck with this branch applied, inspected `[Content_Types].xml`:

| metric | before | after |
|---|---:|---:|
| `slideMaster<N>.xml` Override count for 2-slide deck | 2 (ghost) | 1 |
| `Extension="jpg" ContentType="image/jpg"` | 1 | 0 |
| `Extension="jpg" ContentType="image/jpeg"` | 0 | 1 |
| `slide<N>.xml` Override count | 2 | 2 (unchanged) |
| File opens in PowerPoint Desktop / Keynote / Slides / LibreOffice | ✓ | ✓ |

No behaviour change for lenient parsers; strict-mode warnings cleared.

## Context

Downstream consumer (Skaylink Presentation Generator) is shipping this exact patch via `patch-package` against `pptxgenjs@4.0.1` because the upstream issue has been open since Feb 2026 without movement. Filing this PR as the courtesy upstream contribution so future versions don't need the patch.