### PR TITLE
chore: drop npm:https package dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
 	"name": "pptxgenjs",
-	"version": "4.0.1-beta.0",
+	"version": "4.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pptxgenjs",
-			"version": "4.0.1-beta.0",
+			"version": "4.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^22.8.1",
-				"https": "^1.0.0",
 				"image-size": "^1.2.1",
 				"jszip": "^3.10.1"
 			},
@@ -3583,12 +3582,6 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
-		},
-		"node_modules/https": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
-			"integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==",
-			"license": "ISC"
 		},
 		"node_modules/iconv-lite": {
 			"version": "0.6.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
 	},
 	"dependencies": {
 		"@types/node": "^22.8.1",
-		"https": "^1.0.0",
 		"image-size": "^1.2.1",
 		"jszip": "^3.10.1"
 	},


### PR DESCRIPTION
Originally added in [^1], it's not used. The only place importing `https` is correctly calling `node:https`[^2].

The imported package size is benign (331B installed, package.json only), but the package get's installed 5M times a week. Likely most of it comes from pptxgenjs.

Ref: https://github.com/e18e/ecosystem-issues/issues/262

[^1]:https://github.com/gitbrent/PptxGenJS/commit/fbc9d842957834a3a7e259869de40cff188030bb 
[^2]:https://github.com/gitbrent/PptxGenJS/blob/3c9ec1b687c174952166f6a34b5e87ebf69fa469/dist/pptxgen.es.js#L4843