### PR TITLE
Chart: emit single-level c:strRef categories and relative chart rel targets

### DIFF
--- a/src/gen-charts.ts
+++ b/src/gen-charts.ts
@@ -955,6 +955,19 @@ function makeChartType (chartType: CHART_NAME, data: IOptsChartData[], opts: ICh
 						obj.labels[0].forEach((label, idx) => (strXml += `<c:pt idx="${idx}"><c:v>${encodeXmlEntities(label)}</c:v></c:pt>`))
 						strXml += '    </c:numCache>'
 						strXml += '  </c:numRef>'
+					} else if (obj.labels.length === 1) {
+						// Single-level string categories: emit the idiomatic single-level `c:strRef`
+						// (same form used by the pie/doughnut chart types below). A `c:multiLvlStrRef`
+						// with a single level is valid but non-idiomatic: PowerPoint tolerates it, but
+						// Google Slides / LibreOffice mis-render the category axis and strict parsers
+						// (e.g. pptxtojson) fail to read the labels.
+						strXml += '  <c:strRef>'
+						strXml += `    <c:f>Sheet1!$A$2:$A$${obj.labels[0].length + 1}</c:f>`
+						strXml += '    <c:strCache>'
+						strXml += `      <c:ptCount val="${obj.labels[0].length}"/>`
+						obj.labels[0].forEach((label, idx) => (strXml += `<c:pt idx="${idx}"><c:v>${encodeXmlEntities(label)}</c:v></c:pt>`))
+						strXml += '    </c:strCache>'
+						strXml += '  </c:strRef>'
 					} else {
 						strXml += '  <c:multiLvlStrRef>'
 						strXml += `    <c:f>Sheet1!$A$2:$${getExcelColName(obj.labels.length)}$${obj.labels[0].length + 1}</c:f>`

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -783,7 +783,12 @@ function slideObjectRelationsToXml (slide: PresSlide | SlideLayout, defaultRels:
 	})
 	; (slide._relsChart || []).forEach((rel: ISlideRelChart) => {
 		lastRid = Math.max(lastRid, rel.rId)
-		strXml += `<Relationship Id="rId${rel.rId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="${rel.Target}"/>`
+		// Relationship targets are relative to the slide part, e.g. "../charts/chartN.xml" (what
+		// PowerPoint writes). The stored `rel.Target` is the absolute "/ppt/charts/chartN.xml" form,
+		// which is reused verbatim as the absolute Content_Types PartName. Absolute relationship
+		// targets are valid but non-idiomatic and are mishandled by stricter consumers (e.g.
+		// pptxtojson resolves them to an invalid path and drops the chart), so relativize here only.
+		strXml += `<Relationship Id="rId${rel.rId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="${rel.Target.replace(/^\/ppt\//, '../')}"/>`
 	})
 	; (slide._relsMedia || []).forEach((rel: ISlideRelMedia) => {
 		const relRid = rel.rId.toString()


### PR DESCRIPTION
## Change Summary

Two small changes to how charts are serialized so the output matches what PowerPoint itself writes, improving compatibility with other consumers (Google Slides, LibreOffice, and OOXML parsers) with no change to how PowerPoint renders the charts.

## Change Description

1. **`src/gen-charts.ts` — categories:** bar/line/area charts wrote single-level string categories as `<c:multiLvlStrRef>` (the multi-level form). This now emits the idiomatic single-level `<c:strRef>` when there is exactly one category level, falling back to `<c:multiLvlStrRef>` only for genuine multi-level categories. This mirrors the pie/doughnut category code, which already uses `<c:strRef>`.

2. **`src/gen-xml.ts` — relationship target:** the slide→chart relationship `Target` was written as an absolute `/ppt/charts/chartN.xml`. PowerPoint writes this relative (`../charts/chartN.xml`). The target is now relativized in the slide `.rels`, while the `[Content_Types].xml` `Override PartName` (which requires the absolute form) is left unchanged.

Both prior forms are valid OOXML that PowerPoint tolerates, but they diverge from PowerPoint's own output.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

No new/changed public properties or APIs, so no `core-interfaces.ts` / `types/index.d.ts` / demo changes are required.

## Motivation and Context

Charts produced by pptxgenjs render correctly in PowerPoint but:
- **Google Slides / LibreOffice** mis-render the category axis (caused by the single-level `multiLvlStrRef`).
- **Strict OOXML parsers** (e.g. `pptxtojson`) either can't read the category labels or drop the chart entirely — the latter because they resolve the absolute relationship target to an invalid path.

Aligning both to PowerPoint's idiomatic output fixes these while leaving PowerPoint rendering identical.

## Verification

- `npm run build` compiles cleanly with the changes.
- Verified end-to-end that a generated bar chart now round-trips through an OOXML parser: the `<c:cat>` is a single-level `<c:strRef>`, the slide rel target is `../charts/chart1.xml`, and category labels + values parse correctly.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in the changed areas
- [x] "Run All Demos" browser check — not run (headless); please verify in CI/demo