### PR TITLE
Document gradient fills

### DIFF
--- a/docs/api-shapes.md
+++ b/docs/api-shapes.md
@@ -50,7 +50,7 @@ slide.addText("ShapeType.line", {
 | Name         | Type                                                                    | Description         | Possible Values                                             |
 | :----------- | :---------------------------------------------------------------------- | :------------------ | :---------------------------------------------------------- |
 | `align`      | string                                                                  | alignment           | `left` or `center` or `right`. Default: `left`              |
-| `fill`       | [ShapeFillProps](/PptxGenJS/docs/types#fill-props-shapefillprops)       | fill props          | Fill color/transparency props                               |
+| `fill`       | [ShapeFillProps](/PptxGenJS/docs/types#shape-fill-props-shapefillprops) | fill props          | Solid or gradient fill props                                |
 | `flipH`      | boolean                                                                 | flip Horizontal     | `true` or `false`                                           |
 | `flipV`      | boolean                                                                 | flip Vertical       | `true` or `false`                                           |
 | `hyperlink`  | [HyperlinkProps](/PptxGenJS/docs/types#hyperlink-props-hyperlinkprops)  | hyperlink props     | (see type link)                                             |
@@ -59,6 +59,91 @@ slide.addText("ShapeType.line", {
 | `rotate`     | number                                                                  | rotation (degrees)  | -360 to 360. Default: `0`                                   |
 | `shadow`     | [ShadowProps](/PptxGenJS/docs/types#shadow-props-shadowprops)           | shadow props        | (see type link)                                             |
 | `shapeName`  | string                                                                  | optional shape name | Ex: "Customer Network Diagram 99"                           |
+
+## Gradient Fills
+
+Set `fill.type` to `"gradient"` and provide a [`ShapeGradientProps`](/PptxGenJS/docs/types#shape-gradient-props-shapegradientprops) object in `fill.gradient`. A gradient requires at least two color stops. If fewer are provided, PptxGenJS uses a solid fill instead.
+
+### Linear Gradient
+
+Linear gradients are the default. `angle` is measured clockwise in degrees: `0` is left-to-right and `90` is top-to-bottom. Each stop can also specify its own transparency percentage.
+
+```typescript
+slide.addShape(pres.ShapeType.rect, {
+  x: 1,
+  y: 1,
+  w: 4,
+  h: 2,
+  fill: {
+    type: "gradient",
+    gradient: {
+      angle: 45,
+      stops: [
+        { pos: 0, color: "4472C4" },
+        { pos: 50, color: "70AD47" },
+        { pos: 100, color: "FFC000", transparency: 25 },
+      ],
+    },
+  },
+});
+```
+
+### Radial Gradient
+
+Set the gradient `type` to `"radial"`:
+
+```typescript
+slide.addShape(pres.ShapeType.ellipse, {
+  x: 1,
+  y: 3.5,
+  w: 3,
+  h: 2,
+  fill: {
+    type: "gradient",
+    gradient: {
+      type: "radial",
+      stops: [
+        { pos: 0, color: "FFFFFF" },
+        { pos: 100, color: "4472C4" },
+      ],
+    },
+  },
+});
+```
+
+### Gradient Lines and Slide Backgrounds
+
+The same gradient definition can be used with `line` or `slide.background`:
+
+```typescript
+slide.addShape(pres.ShapeType.line, {
+  x: 5,
+  y: 1,
+  w: 4,
+  h: 0,
+  line: {
+    type: "gradient",
+    width: 4,
+    gradient: {
+      stops: [
+        { pos: 0, color: "4472C4" },
+        { pos: 100, color: "ED7D31" },
+      ],
+    },
+  },
+});
+
+slide.background = {
+  type: "gradient",
+  gradient: {
+    angle: 90,
+    stops: [
+      { pos: 0, color: "D9EAF7" },
+      { pos: 100, color: "FFFFFF" },
+    ],
+  },
+};
+```
 
 ## Examples
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -66,7 +66,7 @@ The PptxGenJS interfaces referenced in surrounding documentation. See the [compl
 | Name         | Type                                               | Description         | Possible Values                                   |
 | :----------- | :------------------------------------------------- | :------------------ | :------------------------------------------------ |
 | `align`      | string                                             | alignment           | `left` or `center` or `right`. Default: `left`    |
-| `fill`       | [ShapeFillProps](#shape-fill-props-shapefillprops) | fill props          | Fill color/transparency props                     |
+| `fill`       | [ShapeFillProps](#shape-fill-props-shapefillprops) | fill props          | Solid or gradient fill props                      |
 | `flipH`      | boolean                                            | flip Horizontal     | `true` or `false`                                 |
 | `flipV`      | boolean                                            | flip Vertical       | `true` or `false`                                 |
 | `hyperlink`  | [HyperlinkProps](#hyperlink-props-hyperlinkprops)  | hyperlink props     | (see type link)                                   |
@@ -78,13 +78,34 @@ The PptxGenJS interfaces referenced in surrounding documentation. See the [compl
 
 ## Shape Fill Props (`ShapeFillProps`)
 
-| Name           | Type   | Default  | Description  | Possible Values                                     |
-| :------------- | :----- | :------- | :----------- | :-------------------------------------------------- |
-| `color`        | string | `000000` | fill color   | hex color or [scheme color](./shapes-and-schemes.md). |
-| `transparency` | number | `0`      | transparency | transparency percentage: 0-100                      |
-| `type`         | string | `solid`  | fill type    | shape fill type                                     |
+| Name           | Type                                                        | Default | Description              | Possible Values                                       |
+| :------------- | :---------------------------------------------------------- | :------ | :----------------------- | :---------------------------------------------------- |
+| `color`        | string                                                        |         | fill color               | hex color or [scheme color](./shapes-and-schemes.md). |
+| `gradient`     | [ShapeGradientProps](#shape-gradient-props-shapegradientprops) |         | gradient fill definition | required when `type` is `gradient`                    |
+| `transparency` | number                                                        | `0`     | transparency             | transparency percentage: 0-100                        |
+| `type`         | string                                                        | `solid` | fill type                | `none`, `solid`, or `gradient`                        |
+
+## Shape Gradient Props (`ShapeGradientProps`)
+
+| Name              | Type                                                                       | Default  | Description                         | Possible Values                                               |
+| :---------------- | :------------------------------------------------------------------------- | :------- | :---------------------------------- | :------------------------------------------------------------ |
+| `angle`           | number                                                                     | `0`      | clockwise linear-gradient angle     | degrees; `0` is left-to-right and `90` is top-to-bottom       |
+| `rotateWithShape` | boolean                                                                    | `true`   | rotate the gradient with the shape  | `true` or `false`                                             |
+| `scaled`          | boolean                                                                    | `false`  | scale the angle with the fill region | `true` or `false`; applies to linear gradients                 |
+| `stops`           | [ShapeGradientStopProps](#shape-gradient-stop-props-shapegradientstopprops)[] | required | gradient color stops                | at least two stops; sorted by `pos`                            |
+| `type`            | string                                                                     | `linear` | gradient geometry                   | `linear` or `radial`                                          |
+
+## Shape Gradient Stop Props (`ShapeGradientStopProps`)
+
+| Name           | Type   | Default  | Description                   | Possible Values                                       |
+| :------------- | :----- | :------- | :---------------------------- | :---------------------------------------------------- |
+| `color`        | string | required | stop color                    | hex color or [scheme color](./shapes-and-schemes.md). |
+| `pos`          | number | required | position along the gradient   | percentage: 0-100                                     |
+| `transparency` | number | `0`      | transparency for this stop    | percentage: 0-100                                     |
 
 ## Shape Line Props (`ShapeLineProps`)
+
+`ShapeLineProps` includes all [ShapeFillProps](#shape-fill-props-shapefillprops), so lines can also use gradient fills.
 
 | Name             | Type   | Default | Description         | Possible Values                                                                          |
 | :--------------- | :----- | :------ | :------------------ | :--------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Change Summary

Adds gradient fill documentation to the Shapes API and Type Interfaces pages.

## Change Description

- Documents linear and radial gradient fills
- Adds examples for shapes, lines, and slide backgrounds
- Documents per-stop transparency
- Documents `angle`, `scaled`, and `rotateWithShape`
- Adds reference tables for `ShapeGradientProps` and `ShapeGradientStopProps`
- Clarifies that `ShapeLineProps` inherits gradient options from `ShapeFillProps`
- Documents the solid-fill fallback when fewer than two stops are provided

## Change Type

- Bug fix
- New feature
- [x] Documentation update

## Related Issue

Companion documentation for #1469, which adds gradient fill support and addresses #102 and #93.

## Motivation and Context

The gradient API introduced by #1469 needs user-facing documentation outside the main README and the demo slides. This update places usage examples on the Shapes API page and documents the complete public interface on the Type Interfaces page.

## Checklist before requesting a review

- [x] If it is a core feature, I have added new code under `/demos/modules/` (included in companion PR #1469)
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new eslint warnings (documentation-only change)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (not applicable to this documentation-only change)
- [x] I have included code/tests that prove my fix is effective or that my feature works (production Docusaurus build passes)
- [x] I have used the "Run All Demos" feature on the [browser demo](/demos/browser/index.html) and no errors were found (verified for companion PR #1469)

## Screenshots / Sample Code

The Shapes documentation includes examples for linear gradients, radial gradients, per-stop transparency, gradient lines, and slide backgrounds.

Thanks for your contribution!