### PR TITLE
chore: remove unused image-size dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
 			"dependencies": {
 				"@types/node": "^22.8.1",
 				"https": "^1.0.0",
-				"image-size": "^1.2.1",
 				"jszip": "^3.10.1"
 			},
 			"devDependencies": {
@@ -3634,21 +3633,6 @@
 				"node": ">= 4"
 			}
 		},
-		"node_modules/image-size": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-			"integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-			"license": "MIT",
-			"dependencies": {
-				"queue": "6.0.2"
-			},
-			"bin": {
-				"image-size": "bin/image-size.js"
-			},
-			"engines": {
-				"node": ">=16.x"
-			}
-		},
 		"node_modules/immediate": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -4992,15 +4976,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/queue": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
-			"integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "~2.0.3"
 			}
 		},
 		"node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
 		"express": false,
 		"fs": false,
 		"https": false,
-		"image-size": false,
 		"node:fs": false,
 		"node:https": false,
 		"os": false,
@@ -40,7 +39,6 @@
 	"dependencies": {
 		"@types/node": "^22.8.1",
 		"https": "^1.0.0",
-		"image-size": "^1.2.1",
 		"jszip": "^3.10.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Change Summary

Remove the unused `image-size` runtime dependency and its browser stub, then prune its lockfile-only `image-size` and `queue` nodes.

## Change Description

The library source does not import or require `image-size`. Keeping it in the runtime dependency graph currently exposes downstream consumers to two high-severity advisories with no patched release:

- https://github.com/advisories/GHSA-w3rx-r6r6-pgpr
- https://github.com/advisories/GHSA-5p2g-fcmc-qvqq

The `image-size` repository is archived and npm currently has no version newer than the affected range. Since PptxGenJS does not call it, removing the unused dependency avoids the vulnerable install without changing runtime behavior.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Motivation and Context

This keeps the published runtime dependency graph free of the unpatched `image-size` advisories while preserving the existing PptxGenJS build and image-generation behavior.

## Verification

- `npm ci --ignore-scripts` — pass
- `npx tsc --noEmit` — pass
- `npm run build` — pass
- Rollup outputs (`pptxgen.js`, `pptxgen.cjs.js`, `pptxgen.es.js`) are byte-identical to the base build
- Node runtime smoke generated a PPTX containing both text and a PNG image — pass
- `npm pack --dry-run` — pass
- `npm audit --omit=dev`: **1 high → 0**
- `npm ls image-size --all`: empty
- `git diff --check` — pass

`npx eslint src --max-warnings=0` still reports the existing `isMultiTypeChart` unused-variable error in `src/gen-charts.ts`; the same error reproduces on the unmodified base commit and this PR does not touch source files.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have included verification that proves the dependency is unused by the build/runtime path
- [ ] I have used the "Run All Demos" browser feature (not needed for a dependency-only change; Node text/image smoke and byte-identical builds were used instead)
