### PR TITLE
build: remove unused image-size dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,16 @@
 {
 	"name": "pptxgenjs",
-	"version": "4.0.1-beta.0",
+	"version": "4.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pptxgenjs",
-			"version": "4.0.1-beta.0",
+			"version": "4.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^22.8.1",
 				"https": "^1.0.0",
-				"image-size": "^1.2.1",
 				"jszip": "^3.10.1"
 			},
 			"devDependencies": {
@@ -3634,21 +3633,6 @@
 				"node": ">= 4"
 			}
 		},
-		"node_modules/image-size": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-			"integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-			"license": "MIT",
-			"dependencies": {
-				"queue": "6.0.2"
-			},
-			"bin": {
-				"image-size": "bin/image-size.js"
-			},
-			"engines": {
-				"node": ">=16.x"
-			}
-		},
 		"node_modules/immediate": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -4992,15 +4976,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/queue": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
-			"integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "~2.0.3"
 			}
 		},
 		"node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
 		"express": false,
 		"fs": false,
 		"https": false,
-		"image-size": false,
 		"node:fs": false,
 		"node:https": false,
 		"os": false,
@@ -40,7 +39,6 @@
 	"dependencies": {
 		"@types/node": "^22.8.1",
 		"https": "^1.0.0",
-		"image-size": "^1.2.1",
 		"jszip": "^3.10.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
# Submission Guidelines

- Only modify the `src/*.ts` files (do not submit `dist` or `src/bld` files) — **no `dist` or `src/bld` files included**; this is a manifest-only change (`package.json` + `package-lock.json`), matching the shape of the previous dependency commit `9b1b8b8` ("updated image-size for pull #1387")
- New and updated properties must be added to `src/core-interfaces.ts` and `types/index.d.ts` — **N/A**, no properties added or changed
- New and updated features must be included in the corresponding `demos/modules/*.mjs` file — **N/A**, not a feature

## Change Summary

Removes `image-size` from `dependencies`. It is declared as a runtime dependency but never imported.

## Change Description

The only reference to it in the codebase is inside `getSizeFromImage()` in `src/gen-media.ts`, which is commented out and marked unused:

```ts
/**
 * FIXME: TODO: currently unused
 * TODO: Should return a Promise
 */
/*
function getSizeFromImage (inImgUrl: string): { width: number, height: number } {
    const sizeOf = typeof require !== 'undefined' ? require('sizeof') : null // NodeJS
```

Note that even if that block were re-enabled it would not resolve `image-size` — it requires `'sizeof'`, which is not in the dependency tree at all.

The `browser` field stub (`"image-size": false`) is removed alongside it, since it becomes dead config once the dependency is gone.

No new npm libraries are needed; this only removes one.

## Change Type

- [x] Bug fix (packaging — declared dependency that is never used)
- [ ] New feature
- [ ] Documentation update

## Related Issue

None. Raised from downstream dependency-audit findings — see Motivation below.

## Motivation and Context

`image-size` currently has **no patched release**. Two HIGH advisories:

- [GHSA-w3rx-r6r6-pgpr](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr) — ICNS parser infinite loop (CVE-2025-71330)
- [GHSA-5p2g-fcmc-qvqq](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq) — JXL/HEIF parser infinite loops (CVE-2025-71329)

Both cover `<= 2.0.2`, and 2.0.2 is the latest published version. There is nothing to upgrade to.

The practical effect is that every `pptxgenjs` install surfaces two unfixable HIGH findings for code that never executes, and `npm audit fix --force` "resolves" them by proposing a major downgrade of pptxgenjs itself:

```
fix available via `npm audit fix --force`
Will install pptxgenjs@1.1.5, which is a breaking change
node_modules/image-size
  pptxgenjs  1.1.5-1 || >=1.1.6
  Depends on vulnerable versions of image-size
```

That leaves downstream consumers either accepting the risk with a written justification or suppressing the alerts. Dropping the unused declaration removes the finding at its source instead.

For the record, the advisories are not false positives — calling `imageSize()` directly on a crafted ICNS buffer with a zero-valued entry length hangs the process indefinitely. The flaw is real; it is simply unreachable through `pptxgenjs`.

## Checklist before requesting a review

- [x] If it is a core feature, I have added new code under `/demos/modules/` — N/A, not a feature
- [x] My code follows the style guidelines of this project — no code changed
- [x] My changes generate no new eslint warnings — no `src` files touched
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas — N/A, no code changed
- [x] I have included code/tests that prove my fix is effective — see verification below
- [x] I have used the "Run All Demos" feature — ran the **Node** demo suite (`npm run demo-all`) rather than the browser demo, since this change only affects Node dependency resolution; details below

## Verification

**1. Build output is byte-identical.** I md5'd `src/bld/pptxgen.js`, `pptxgen.cjs.js` and `pptxgen.es.js` on `master`, applied the change, reinstalled and rebuilt — all three hashes match:

```
1161a0a237b349fc952492f456ad7ad7  pptxgen.es.js
40ce5df101f352f5a5b4dcb0d259781e  pptxgen.cjs.js
194032fcbd440cf2145df1aa40d8a164  pptxgen.js
```

Nothing references `image-size`, so rollup's `external: [...Object.keys(pkg.dependencies)]` had nothing to externalize.

**2. `grep -c "image-size"` is `0`** across all three built bundles, both before and after.

**3. Full Node demo suite passes with `image-size` absent from the tree.** Installed the modified local package into `demos/node` (confirmed `node_modules/image-size` absent), then ran `npm run demo-all`, which exercises Master, Chart, **Image**, Media, Shape, Text and Table:

```
* pptxgenjs ver: 4.0.1
--------------------==~==~==~==[ ...DEMO COMPLETE ]==~==~==~==--------------------
EX1 exported: PptxGenJS_Demo_Master,Chart,Image,Media,Shape,Text,Table_...pptx
```

Completed with no errors and a valid deck. The Image module in particular runs fine without the package present.

## Note

`https: ^1.0.0` in `dependencies` looks similarly vestigial — it also has a `browser: false` stub and appears unused. I left it out to keep this PR focused, but happy to address it separately if useful.