### PR TITLE
fix: unique p:cNvPr/@id for table+shape slides

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
 		"start": "gulp",
 		"ship": "gulp ship",
 		"defs": "gulp reactTestDefs",
-		"watch": "rollup -cw"
+		"watch": "rollup -cw",
+		"test": "npm run build && node --test test/*.cjs"
 	},
 	"browser": {
 		"express": false,

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -84,7 +84,10 @@ const ImageSizingXml = {
  */
 function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 	let strSlideXml: string = slide._name ? '<p:cSld name="' + slide._name + '">' : '<p:cSld>'
-	let intTableNum = 1
+	// ECMA-376: p:cNvPr/@id must be unique within the slide's p:spTree.
+	// id="1" is reserved for p:nvGrpSpPr; remaining ids are allocated monotonically.
+	let nextCnvPrId = 2
+	const allocCnvPrId = (): number => nextCnvPrId++
 
 	// STEP 1: Add background color/image (ensure only a single `<p:bg>` tag is created, ex: when master-baskground has both `color` and `path`)
 	if (slide._bkgdImgRid) {
@@ -103,7 +106,7 @@ function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 	strSlideXml += '<a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr>'
 
 	// STEP 3: Loop over all Slide.data objects and add them to this slide
-	slide._slideObjects.forEach((slideItemObj: ISlideObject, idx: number) => {
+	slide._slideObjects.forEach((slideItemObj: ISlideObject) => {
 		let x = 0
 		let y = 0
 		let cx = getSmartParseNumber('75%', 'X', slide._presLayout)
@@ -172,7 +175,7 @@ function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 
 				// STEP 1: Start Table XML
 				// NOTE: Non-numeric cNvPr id values will trigger "presentation needs repair" type warning in MS-PPT-2013
-				strXml = `<p:graphicFrame><p:nvGraphicFramePr><p:cNvPr id="${intTableNum * slide._slideNum + 1}" name="${slideItemObj.options.objectName}"/>`
+				strXml = `<p:graphicFrame><p:nvGraphicFramePr><p:cNvPr id="${allocCnvPrId()}" name="${slideItemObj.options.objectName}"/>`
 				strXml +=
 					'<p:cNvGraphicFramePr><a:graphicFrameLocks noGrp="1"/></p:cNvGraphicFramePr>' +
 					'  <p:nvPr><p:extLst><p:ext uri="{D42A27DB-BD31-4B8C-83A1-F6EECF244321}"><p14:modId xmlns:p14="http://schemas.microsoft.com/office/powerpoint/2010/main" val="1579011935"/></p:ext></p:extLst></p:nvPr>' +
@@ -382,8 +385,6 @@ function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 				// STEP 6: Set table XML
 				strSlideXml += strXml
 
-				// LAST: Increment counter
-				intTableNum++
 				break
 
 			case SLIDE_OBJECT_TYPES.text:
@@ -409,7 +410,7 @@ function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 				strSlideXml += '<p:sp>'
 
 				// B: The addition of the "txBox" attribute is the sole determiner of if an object is a shape or textbox
-				strSlideXml += `<p:nvSpPr><p:cNvPr id="${idx + 2}" name="${slideItemObj.options.objectName}">`
+				strSlideXml += `<p:nvSpPr><p:cNvPr id="${allocCnvPrId()}" name="${slideItemObj.options.objectName}">`
 				// <Hyperlink>
 				if (slideItemObj.options.hyperlink?.url) {
 					strSlideXml += `<a:hlinkClick r:id="rId${slideItemObj.options.hyperlink._rId}" tooltip="${slideItemObj.options.hyperlink.tooltip ? encodeXmlEntities(slideItemObj.options.hyperlink.tooltip) : ''}"/>`
@@ -556,7 +557,7 @@ function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 			case SLIDE_OBJECT_TYPES.image:
 				strSlideXml += '<p:pic>'
 				strSlideXml += '  <p:nvPicPr>'
-				strSlideXml += `<p:cNvPr id="${idx + 2}" name="${slideItemObj.options.objectName}" descr="${encodeXmlEntities(
+				strSlideXml += `<p:cNvPr id="${allocCnvPrId()}" name="${slideItemObj.options.objectName}" descr="${encodeXmlEntities(
 					slideItemObj.options.altText || slideItemObj.image
 				)}">`
 				if (slideItemObj.hyperlink?.url) {
@@ -676,7 +677,7 @@ function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 			case SLIDE_OBJECT_TYPES.chart:
 				strSlideXml += '<p:graphicFrame>'
 				strSlideXml += ' <p:nvGraphicFramePr>'
-				strSlideXml += `   <p:cNvPr id="${idx + 2}" name="${slideItemObj.options.objectName}" descr="${encodeXmlEntities(slideItemObj.options.altText || '')}"/>`
+				strSlideXml += `   <p:cNvPr id="${allocCnvPrId()}" name="${slideItemObj.options.objectName}" descr="${encodeXmlEntities(slideItemObj.options.altText || '')}"/>`
 				strSlideXml += '   <p:cNvGraphicFramePr/>'
 				strSlideXml += `   <p:nvPr>${genXmlPlaceholder(placeholderObj)}</p:nvPr>`
 				strSlideXml += ' </p:nvGraphicFramePr>'
@@ -702,7 +703,7 @@ function slideObjectToXml (slide: PresSlide | SlideLayout): string {
 
 		strSlideXml += '<p:sp>'
 		strSlideXml += ' <p:nvSpPr>'
-		strSlideXml += '  <p:cNvPr id="25" name="Slide Number Placeholder 0"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr>'
+		strSlideXml += `  <p:cNvPr id="${allocCnvPrId()}" name="Slide Number Placeholder 0"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr>`
 		strSlideXml += '  <p:nvPr><p:ph type="sldNum" sz="quarter" idx="4294967295"/></p:nvPr>'
 		strSlideXml += ' </p:nvSpPr>'
 		strSlideXml += ' <p:spPr>'

--- a/test/cnvpr-ids.test.cjs
+++ b/test/cnvpr-ids.test.cjs
@@ -1,0 +1,61 @@
+/**
+ * ECMA-376: p:cNvPr/@id must be unique within a slide's p:spTree.
+ * Regression for gitbrent/PptxGenJS#1532 (table + other shape).
+ */
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const JSZip = require('jszip')
+
+function loadPptxGenJS () {
+	const built = path.join(__dirname, '../src/bld/pptxgen.cjs.js')
+	const dist = path.join(__dirname, '../dist/pptxgen.cjs.js')
+	return require(fs.existsSync(built) ? built : dist)
+}
+
+function extractCnvPrIds (xml) {
+	return [...xml.matchAll(/<p:cNvPr\b[^>]*\bid="(\d+)"/g)].map(m => Number(m[1]))
+}
+
+async function slideXml (pptx, slidePath) {
+	const buf = await pptx.write({ outputType: 'nodebuffer' })
+	const zip = await JSZip.loadAsync(buf)
+	const entry = zip.file(slidePath)
+	assert.ok(entry, `missing zip entry ${slidePath}`)
+	return entry.async('string')
+}
+
+function assertUniqueCnvPrIds (ids, label) {
+	assert.ok(ids.length >= 3, `${label}: expected nvGrpSpPr + objects, got [${ids.join(', ')}]`)
+	assert.equal(ids[0], 1, `${label}: p:nvGrpSpPr must keep id="1"`)
+	assert.equal(
+		new Set(ids).size,
+		ids.length,
+		`${label}: duplicate p:cNvPr/@id [${ids.join(', ')}]`
+	)
+}
+
+test('p:cNvPr/@id values are unique when a slide has a table and a text shape', async () => {
+	const PptxGenJS = loadPptxGenJS()
+	const pptx = new PptxGenJS()
+	const slide = pptx.addSlide()
+	slide.addText('A text box', { x: 0.5, y: 0.5, w: 4, h: 0.5 })
+	slide.addTable([[{ text: 'A' }, { text: 'B' }]], { x: 0.5, y: 1.5, w: 4 })
+
+	const xml = await slideXml(pptx, 'ppt/slides/slide1.xml')
+	assertUniqueCnvPrIds(extractCnvPrIds(xml), 'slide1 text+table')
+})
+
+test('p:cNvPr/@id values stay unique on later slides and with mixed object order', async () => {
+	const PptxGenJS = loadPptxGenJS()
+	const pptx = new PptxGenJS()
+	pptx.addSlide()
+	const slide = pptx.addSlide()
+	slide.addTable([[{ text: 'A' }, { text: 'B' }]], { x: 0.5, y: 1.5, w: 4 })
+	slide.addText('A text box', { x: 0.5, y: 0.5, w: 4, h: 0.5 })
+	slide.addShape(pptx.ShapeType.rect, { x: 5, y: 0.5, w: 1, h: 1 })
+
+	const xml = await slideXml(pptx, 'ppt/slides/slide2.xml')
+	assertUniqueCnvPrIds(extractCnvPrIds(xml), 'slide2 table+text+shape')
+})


### PR DESCRIPTION
# Submission Guidelines

- Only modify the `src/*.ts` files (do not submit `dist` or `src/bld` files)
- New and updated properties must be added to `src/core-interfaces.ts` and `types/index.d.ts`
- New and updated features must be included in the corresponding `demos/modules/*.mjs` file
- Review previously accepted changes for examples on what to provide

## Change Summary

Give tables, text, images, charts, and slide-number shapes a single per-slide `p:cNvPr/@id` allocator so a table and any other shape no longer emit the same id.

## Change Description

`slideObjectToXml` used two independent formulas:

- tables: `intTableNum * slide._slideNum + 1` (first table on slide 1 → `2`)
- other shapes: `idx + 2` (first shape → `2`)

ECMA-376 requires `CT_NonVisualDrawingProps` ids unique within a slide `spTree`. A text box plus a table produced `1, 2, 2`.

Ids now come from one monotonic counter (`id="1"` stays reserved for `p:nvGrpSpPr`). Media still uses `mediaRid + 2` because PowerPoint ties that id to the preview-image relationship.

A small `node:test` fixture asserts uniqueness for the reporter's table+text case and for mixed objects on a later slide.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Related Issue

Reported by @aramosmi. Fixes #1532.

## Motivation and Context

Duplicate `p:cNvPr/@id` values are invalid OOXML. Stricter consumers may reject or repair the file; tools that key on `@id` see two shapes with the same identity.

## Checklist before requesting a review

- [ ] If it is a core feature, I have added new code under `/demos/modules/`
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new eslint warnings
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have included code/tests that prove my fix is effective or that my feature works
- [ ] I have used the "Run All Demos" feature on the [browser demo](/demos/browser/index.html) and no errors were found

## Screenshots / Sample Code (if appropriate)

```
p:cNvPr @id values in slide1 spTree: 1, 2, 3
unique: YES
```

Thanks for your contribution!